### PR TITLE
Fix cleanup regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ dist: bindata.go vendor
 	mkdir -p bin
 	for arch in $(ALL_ARCH); do \
 		for platform in $(ALL_GOOS); do \
-			GOOS=$$platform ARCH=$$arch $(GOBUILD) -o bin/$(NAME).$$arch.$$platform; \
+			CGO_ENABLED=0 GOOS=$$platform ARCH=$$arch $(GOBUILD) -o bin/$(NAME).$$platform.$$arch; \
 		done; \
 	done
 

--- a/conduit.go
+++ b/conduit.go
@@ -133,10 +133,11 @@ var ConnectService = &cobra.Command{
 		}
 		defer func() {
 			if ConduitReuse {
-				debug("destroying", ConduitAppName, appGuid)
-				if err := client.DestroyApp(appGuid); err != nil {
-					debug("failed to cleanup", ConduitAppName, "app:", err)
-				}
+				return
+			}
+			debug("destroying", ConduitAppName, appGuid)
+			if err := client.DestroyApp(appGuid); err != nil {
+				debug("failed to cleanup", ConduitAppName, "app:", err)
 			}
 		}()
 		// upload bits if not staged


### PR DESCRIPTION
# What

* Fixes a regression introduced in previous commit that prevents `__conduit__` apps being destroy.
* Updates makefile used to create release binaries.

# How to review

* sanity check
* do `cf conduit pg -- pg_dump` ...then check `cf a` a few seconds after completion... there should be no __conduit__ app running.

# Who can review

Not @chrisfarms