### PR TITLE
 Missing argument to fmt.Errorf + test in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - 1.8
+  - 1.9
+  - master
+
+install:
+  - go get -u github.com/golang/dep/cmd/dep
+  - go get ./...
+
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,8 @@ vendor:
 clean:
 	rm -rf vendor
 	rm -rf bin
+
+.PHONY: test
+test:
+	go vet
+	go test ./...

--- a/conduit.go
+++ b/conduit.go
@@ -291,7 +291,7 @@ var ConnectService = &cobra.Command{
 			status.Text("Preparing command:", runargs)
 			exe, err := exec.LookPath(runargs[0])
 			if err != nil {
-				return fmt.Errorf("cannot find '%s' in PATH")
+				return fmt.Errorf("cannot find '%s' in PATH", runargs[0])
 			}
 			proc := exec.Command(exe, runargs[1:]...)
 			proc.Env = os.Environ()


### PR DESCRIPTION
## What

I noticed this while running the plugin without `pg_dump` installed locally.
The `go vet` command, which is now run by Travis, also finds this:

    ➜  paas-cf-conduit git:(master) ✗ go vet
    conduit.go:294: missing argument for Errorf("%s"): format reads arg 1, have only 0 args

Run this in Travis to prevent it happening again.

## How to review

Code review should be sufficient. Also check that Travis reports a successful build.