### PR TITLE
[#153437663] Add license fix build

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Crown Copyright (Government Digital Service)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 NAME = cf-conduit
 GOBUILD = go build
-ALL_ARCH = amd64 386
+ALL_GOARCH = amd64 386
 ALL_GOOS = windows linux darwin
 
 .PHONY: install
@@ -13,9 +13,10 @@ install:
 .PHONY: dist
 dist:
 	mkdir -p bin
-	for arch in $(ALL_ARCH); do \
+	for arch in $(ALL_GOARCH); do \
 		for platform in $(ALL_GOOS); do \
-			CGO_ENABLED=0 GOOS=$$platform ARCH=$$arch $(GOBUILD) -o bin/$(NAME).$$platform.$$arch; \
+			CGO_ENABLED=0 GOOS=$$platform GOARCH=$$arch $(GOBUILD) -o bin/$(NAME).$$platform.$$arch; \
+			shasum -a 1 bin/$(NAME).$$platform.$$arch | cut -d ' ' -f 1 > bin/$(NAME).$$platform.$$arch.sha1; \
 		done; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,11 @@ install:
 
 .PHONY: dist
 dist:
-	mkdir -p bin
-	for arch in $(ALL_GOARCH); do \
-		for platform in $(ALL_GOOS); do \
-			CGO_ENABLED=0 GOOS=$$platform GOARCH=$$arch $(GOBUILD) -o bin/$(NAME).$$platform.$$arch; \
-			shasum -a 1 bin/$(NAME).$$platform.$$arch | cut -d ' ' -f 1 > bin/$(NAME).$$platform.$$arch.sha1; \
-		done; \
-	done
+	$(eval export NAME)
+	$(eval export GOBUILD)
+	$(eval export ALL_GOARCH)
+	$(eval export ALL_GOOS)
+	./dist.sh
 
 .PHONY: clean
 clean:

--- a/dist.sh
+++ b/dist.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eo pipefail
+
+mkdir -p bin
+
+for arch in ${ALL_GOARCH}; do
+  for platform in ${ALL_GOOS}; do
+    printf "Building bin/${NAME}.${platform}.${arch}... "
+    CGO_ENABLED=0 GOOS=${platform} GOARCH=${arch} ${GOBUILD} -o bin/${NAME}.${platform}.${arch}
+    shasum -a 1 bin/${NAME}.${platform}.${arch} | cut -d ' ' -f 1 > bin/${NAME}.${platform}.${arch}.sha1
+    cat bin/${NAME}.${platform}.${arch}.sha1
+  done
+done


### PR DESCRIPTION
## What

* Add MIT license
* Fix: Use GOARCH instead of ARCH when building the Go binaries
* Generate SHA1 sums as part of the build process

## How to review

* Check the license file
* Run ```make clean dist``` to see if the binaries were built successfully in bin/ with the appropriate checksums 

## Who can review

Not @bandesz
