### PR TITLE
README: Use mysqldump --result-file instead of redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ cf conduit mysql-instance -- mysql
 Export a mysql database:
 
 ```
-cf conduit mysql-instance -- mysqldump --all-databases > backup.sql
+cf conduit mysql-instance -- mysqldump --result-file backup.sql some_database_name
 ```
 
 Import a mysql dump


### PR DESCRIPTION
# What

@jonathanglassman and I noticed this issue whilst writing the PaaS tech docs for connecting to MySQL / Postgres.

Using the `--result-file` option:

- helps Windows users avoid a carriage return issue
- allows conduit to show progress or errors that would be hidden by the
  redirection

Also, specify a database instead of `--all-databases`, to make it easier
to import the resulting data into a new RDS-broker database. With
`--all-databases`, it's easy to run into permission errors which could be
a stumbling block for new adopters.

# How to review

Read it.

# Who can't review

@camelpunch nor @jonathanglassman