### PR TITLE
[#155431687] Support Redis CLI

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,10 @@
 
 [[projects]]
   name = "code.cloudfoundry.org/cli"
-  packages = ["plugin","plugin/models"]
+  packages = [
+    "plugin",
+    "plugin/models"
+  ]
   revision = "829c87ef317ad6be9d73039934b9f1d82560c403"
   version = "v6.32.0"
 
@@ -12,6 +15,12 @@
   packages = ["."]
   revision = "48dbb65d7bd5c74ab50d53d04c949f20e3d14944"
   version = "1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/cloudfoundry/multierror"
+  packages = ["."]
+  revision = "dafed03eebc65cdf3de2928e3f94793bc893ede0"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -45,13 +54,45 @@
 
 [[projects]]
   name = "github.com/onsi/ginkgo"
-  packages = [".","config","internal/codelocation","internal/containernode","internal/failer","internal/leafnodes","internal/remote","internal/spec","internal/spec_iterator","internal/specrunner","internal/suite","internal/testingtproxy","internal/writer","reporters","reporters/stenographer","reporters/stenographer/support/go-colorable","reporters/stenographer/support/go-isatty","types"]
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types"
+  ]
   revision = "9eda700730cba42af70d53180f9dcce9266bc2bc"
   version = "v1.4.0"
 
 [[projects]]
   name = "github.com/onsi/gomega"
-  packages = [".","format","internal/assertion","internal/asyncassertion","internal/oraclematcher","internal/testingtsupport","matchers","matchers/support/goraph/bipartitegraph","matchers/support/goraph/edge","matchers/support/goraph/node","matchers/support/goraph/util","types"]
+  packages = [
+    ".",
+    "format",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types"
+  ]
   revision = "c893efa28eb45626cdaa76c9f653b62488858837"
   version = "v1.2.0"
 
@@ -70,36 +111,80 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
+  packages = [
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "ssh",
+    "ssh/terminal"
+  ]
   revision = "ca1fcd4ab4c10bc58852a894bcf195fab2229efe"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","html","html/atom","html/charset"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "html",
+    "html/atom",
+    "html/charset"
+  ]
   revision = "01c190206fbdffa42f334f4b2bf2220f50e64920"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal"
+  ]
   revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "8eb05f94d449fdf134ec24630ce69ada5b469c1c"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/utf8internal","language","runes","transform","unicode/cldr"]
+  packages = [
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
+    "internal/gen",
+    "internal/tag",
+    "internal/utf8internal",
+    "language",
+    "runes",
+    "transform",
+    "unicode/cldr"
+  ]
   revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
@@ -112,6 +197,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b10efaaa4a84dfda118492cd758df2c0a243677ba9744b089989b37f00678db1"
+  inputs-digest = "c494ddcd5c195d250540d5954714c084294fe899d7d289022fdbb606743baddd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ Import a mysql dump
 cf conduit mysql-instance -- mysql < backup.sql
 ```
 
+#### Redis
+
+Launch a Redis shell:
+
+```
+cf conduit redis-instance -- redis-cli
+```
+
+Run a Redis command:
+
+```
+cf conduit redis-instance -- redis-cli get mykey
+```
 
 ### Running local processes
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 ![alt text][logo]
 
-The cloudfoundry cli plugin that makes it easy to directly connect to your remote service instances.
+The Cloud Foundry cli plugin that makes it easy to directly connect to your remote service instances.
 
 ## Overview
 
-* Create tunnels to remote service instances running on cloudfoundry to allow direct access.
+* Create tunnels to remote service instances running on Cloud Foundry to allow direct access.
 * Provides a way to invoke cli tools such as `psql` or `mysqldump` for [supported service](#running-database-tools) types.
-* [_experimental_] Enables running local cloudfoundry application processes against live service instances by setting up a tunneled VCAP_SERVICES environment.
+* [_experimental_] Enables running local Cloud Foundry application processes against live service instances by setting up a tunneled VCAP_SERVICES environment.
 
 ## Installation
 
-`cf-conduit` is a Cloudfoundry CLI Plugin. Cloudfoundry plugins are binaries that you download and install using the `cf install-plugin` command. For more general information on installing and using Cloudfoundry CLI Plugins please see [Using CF CLI Plugins](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html#plugin-install)
+`cf-conduit` is a Cloud Foundry CLI Plugin. Cloud Foundry plugins are binaries that you download and install using the `cf install-plugin` command. For more general information on installing and using Cloud Foundry CLI Plugins please see [Using CF CLI Plugins](https://docs.cloudfoundry.org/cf-cli/use-cli-plugins.html#plugin-install)
 
 To install `cf-conduit`:
 
@@ -52,7 +52,7 @@ cf conduit --help
 
 ### Creating tunnels
 
-To tunnel a connection from your cloudfoundry hosted service instance to your local machine:
+To tunnel a connection from your Cloud Foundry hosted service instance to your local machine:
 
 ```
 cf conduit my-service-instance
@@ -138,7 +138,7 @@ For example, if your Ruby based application is located at `/home/myapp/app.rb` a
 cf conduit app-db -- ruby /home/myapp/app.rb
 ```
 
-Alternativly you could drop yourself into a `bash` shell and work from there:
+Alternatively you could drop yourself into a `bash` shell and work from there:
 
 ```
 cf conduit app-db -- bash

--- a/client/client.go
+++ b/client/client.go
@@ -74,6 +74,15 @@ type Credentials struct {
 	JDBCURI  string `json:"jdbcuri"`
 }
 
+func (c *Credentials) SetAddress(host string, port int64) {
+	oldAddr := fmt.Sprintf("%s:%d", c.Host, c.Port)
+	newAddr := fmt.Sprintf("%s:%d", host, port)
+	c.URI = strings.Replace(c.URI, oldAddr, newAddr, 1)
+	c.JDBCURI = strings.Replace(c.JDBCURI, oldAddr, newAddr, 1)
+	c.Host = host
+	c.Port = port
+}
+
 type jsonCredentials struct {
 	Host     string      `json:"host"`
 	Port     json.Number `json:"port"`

--- a/client/client.go
+++ b/client/client.go
@@ -70,6 +70,8 @@ type Credentials struct {
 	Name     string `json:"name"`
 	Username string `json:"username"`
 	Password string `json:"password"`
+	URI      string `json:"uri"`
+	JDBCURI  string `json:"jdbcuri"`
 }
 
 type jsonCredentials struct {
@@ -78,6 +80,8 @@ type jsonCredentials struct {
 	Name     string      `json:"name"`
 	Username string      `json:"username"`
 	Password string      `json:"password"`
+	URI      string      `json:"uri"`
+	JDBCURI  string      `json:"jdbcuri"`
 }
 
 type Org struct {
@@ -339,6 +343,8 @@ func (c *Client) BindService(appGuid string, serviceInstanceGuid string) (*Crede
 		Name:     res.Entity.Credentials.Name,
 		Username: res.Entity.Credentials.Username,
 		Password: res.Entity.Credentials.Password,
+		URI:      res.Entity.Credentials.URI,
+		JDBCURI:  res.Entity.Credentials.JDBCURI,
 	}
 	return creds, nil
 

--- a/client/credentials.go
+++ b/client/credentials.go
@@ -1,0 +1,108 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type Credentials interface {
+	Host() string
+	Port() int64
+	Username() string
+	Password() string
+	Database() string
+	URI() string
+	JDBCURI() string
+	SetAddress(host string, port int64)
+	IsTLSEnabled() bool
+}
+
+type credentials map[string]interface{}
+
+// Get returns with the first existing key's value (case-insensitive comparison)
+func (c credentials) get(keys ...string) string {
+	for _, key := range keys {
+		for k, v := range c {
+			if strings.EqualFold(k, key) {
+				return fmt.Sprintf("%v", v)
+			}
+		}
+	}
+	return ""
+}
+
+func (c credentials) Host() string {
+	return c.get("host", "hostname")
+}
+
+func (c credentials) Port() int64 {
+	port, _ := strconv.Atoi(fmt.Sprintf("%v", c["port"]))
+	return int64(port)
+}
+
+func (c credentials) URI() string {
+	return c.get("uri", "url")
+}
+
+func (c credentials) JDBCURI() string {
+	return c.get("jdbcuri", "jdbcurl", "jdbc_uri", "jdbc_url")
+}
+
+func (c credentials) Username() string {
+	return c.get("user", "username")
+}
+
+func (c credentials) Password() string {
+	return c.get("password", "passwd", "pwd")
+}
+
+func (c credentials) Database() string {
+	return c.get("database", "db", "name")
+}
+
+func (c credentials) IsTLSEnabled() bool {
+	tlsEnabled, _ := strconv.ParseBool(c.get("tls", "tls_enabled", "tlsenabled"))
+	if tlsEnabled {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(c.URI()), "ssl=true") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(c.JDBCURI()), "ssl=true") {
+		return true
+	}
+
+	return false
+}
+
+func (c credentials) SetAddress(host string, port int64) {
+	oldAddr := fmt.Sprintf("%s:%d", c.Host(), c.Port())
+	newAddr := fmt.Sprintf("%s:%d", host, port)
+	for k := range c {
+		if stringVal, ok := c[k].(string); ok {
+			c[k] = strings.Replace(stringVal, oldAddr, newAddr, -1)
+		}
+	}
+
+	for k := range c {
+		if strings.EqualFold(k, "host") || strings.EqualFold(k, "hostname") {
+			c[k] = host
+		}
+	}
+	c["port"] = port
+}
+
+func (c credentials) Fprint(writer io.Writer, indent string) {
+	var keys []string
+	for k := range c {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(writer, "%s%s: %v\n", indent, k, c[k])
+	}
+}

--- a/conduit.go
+++ b/conduit.go
@@ -120,4 +120,5 @@ var ConnectService = &cobra.Command{
 			return nil
 		}
 	},
+	SilenceUsage: true,
 }

--- a/conduit.go
+++ b/conduit.go
@@ -70,9 +70,9 @@ var ConnectService = &cobra.Command{
 		}
 
 		app := conduit.NewApp(
-			cfClient, status, ConduitLocalPort,
-			ConduitOrg, ConduitSpace, ConduitAppName, !ConduitReuse,
-			serviceInstanceNames,
+			cfClient, status,
+			ConduitLocalPort, ConduitOrg, ConduitSpace, ConduitAppName, !ConduitReuse,
+			serviceInstanceNames, runargs,
 		)
 
 		app.RegisterServiceProvider("mysql", &service.MySQL{})
@@ -105,7 +105,7 @@ var ConnectService = &cobra.Command{
 
 		finish := make(chan struct{})
 		if len(runargs) > 0 {
-			if err := app.RunCommand(runargs, finish); err != nil {
+			if err := app.RunCommand(finish); err != nil {
 				return err
 			}
 		} else {

--- a/conduit.go
+++ b/conduit.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alphagov/paas-cf-conduit/client"
 	"github.com/alphagov/paas-cf-conduit/logging"
 	"github.com/alphagov/paas-cf-conduit/tls"
+	"github.com/alphagov/paas-cf-conduit/util"
 
 	"github.com/spf13/cobra"
 )
@@ -99,7 +100,7 @@ var ConnectService = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// create status writer
-		status := NewStatus(os.Stderr)
+		status := util.NewStatus(os.Stderr, NonInteractive)
 		defer status.Done()
 		// parse args
 		var serviceInstanceNames []string

--- a/conduit.go
+++ b/conduit.go
@@ -1,70 +1,18 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"html/template"
-	"io/ioutil"
-	"net"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"time"
 
 	"github.com/alphagov/paas-cf-conduit/client"
+	"github.com/alphagov/paas-cf-conduit/conduit"
 	"github.com/alphagov/paas-cf-conduit/logging"
-	"github.com/alphagov/paas-cf-conduit/tls"
+	"github.com/alphagov/paas-cf-conduit/service"
 	"github.com/alphagov/paas-cf-conduit/util"
 
 	"github.com/spf13/cobra"
 )
-
-const tunnelInfo = `
-The following services are ready for you to connect to:
-
-{{range $serviceName, $services := .VcapServices}}
-	{{range $serviceIndex, $service := $services}}
-		service: {{$service.Name}} ({{$serviceName}})
-		host: {{$service.Credentials.Host}}
-		port: {{$service.Credentials.Port}}
-		username: {{$service.Credentials.Username}}
-		password: {{$service.Credentials.Password}}
-		db: {{$service.Credentials.Name}}
-	{{end}}
-{{end}}
-`
-
-func waitForConnection(addr string) chan error {
-	timeout := 3 * time.Second
-	connection := make(chan error)
-	go func() {
-		defer close(connection)
-		tries := 0
-		for {
-			if tries > 5 {
-				time.Sleep(2 * time.Second)
-			} else {
-				time.Sleep(1 * time.Second)
-			}
-			tries++
-			logging.Debug("waiting for", addr, "attempt", tries)
-			conn, err := net.DialTimeout("tcp", addr, timeout)
-			if err != nil {
-				if tries < 15 {
-					continue
-				}
-				connection <- fmt.Errorf("connection fail after %d attempts: %s", tries, err)
-				break
-			}
-			defer conn.Close()
-			connection <- nil
-			break
-		}
-	}()
-	return connection
-}
 
 var ConnectService = &cobra.Command{
 	Use: "conduit [flags] SERVICE_INSTANCE [-- COMMAND]",
@@ -99,9 +47,6 @@ var ConnectService = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// create status writer
-		status := util.NewStatus(os.Stderr, NonInteractive)
-		defer status.Done()
 		// parse args
 		var serviceInstanceNames []string
 		var runargs []string
@@ -112,264 +57,66 @@ var ConnectService = &cobra.Command{
 			serviceInstanceNames = args
 			runargs = []string{}
 		}
+
+		// create status writer
+		status := util.NewStatus(os.Stderr, NonInteractive)
+		defer status.Done()
+
 		// create a client
 		status.Text("Connecting client")
 		cfClient, err := client.NewClient(ApiEndpoint, ApiToken, ApiInsecure)
 		if err != nil {
 			return err
 		}
-		// get org
-		status.Text("Targeting org", ConduitOrg)
-		org, err := cfClient.GetOrgByName(ConduitOrg)
-		if err != nil {
-			return err
-		}
-		// get space
-		status.Text("Targeting space", ConduitSpace)
-		space, err := cfClient.GetSpaceByName(org.Guid, ConduitSpace)
-		if err != nil {
-			return err
-		}
-		// create tunnel app
-		status.Text("Deploying", ConduitAppName)
-		appGuid, err := cfClient.CreateApp(ConduitAppName, space.Guid)
-		if err != nil {
-			return err
-		}
+
+		app := conduit.NewApp(
+			cfClient, status, ConduitLocalPort,
+			ConduitOrg, ConduitSpace, ConduitAppName, !ConduitReuse,
+			serviceInstanceNames,
+		)
+
+		app.RegisterServiceProvider("mysql", &service.MySQL{})
+		app.RegisterServiceProvider("postgres", &service.Postgres{})
+		app.RegisterServiceProvider("redis", &service.Redis{})
+
 		defer func() {
-			if ConduitReuse {
-				return
-			}
-			logging.Debug("destroying", ConduitAppName, appGuid)
-			if err := cfClient.DestroyApp(appGuid); err != nil {
-				logging.Debug("failed to delete app", ConduitAppName, "err:", err)
-
-				logging.Debug("refreshing auth token")
-				newToken, err := cfClient.GetNewAccessToken()
-				if err != nil {
-					logging.Debug("failed to get new access token, err:", err)
-					fmt.Fprintf(os.Stderr, "failed to delete %s app, please delete it manually\n", ConduitAppName)
-					return
-				}
-				cfClient, err = client.NewClient(ApiEndpoint, newToken, ApiInsecure)
-				if err != nil {
-					logging.Debug("failed to create cf client with new access token, err:", err)
-					fmt.Fprintf(os.Stderr, "failed to delete %s app, please delete it manually\n", ConduitAppName)
-					return
-				}
-
-				if err := cfClient.DestroyApp(appGuid); err != nil {
-					logging.Debug("failed to delete app", ConduitAppName, "err:", err)
-					fmt.Fprintf(os.Stderr, "failed to delete %s app, please delete it manually\n", ConduitAppName)
-					return
-				}
+			if err := app.Teardown(); err != nil {
+				logging.Error(err)
 			}
 		}()
-		// upload bits if not staged
-		status.Text("Uploading", ConduitAppName, "bits")
-		err = cfClient.UploadStaticAppBits(appGuid)
-		if err != nil {
-			return err
-		}
-		// start app
-		status.Text("Starting", ConduitAppName)
-		err = cfClient.UpdateApp(appGuid, map[string]interface{}{
-			"state": "STARTED",
-		})
-		if err != nil {
-			return err
-		}
-		// get service instances
-		status.Text("Fetching service infomation")
-		serviceInstances, err := cfClient.GetServiceInstances(fmt.Sprintf("space_guid:%s", space.Guid))
-		if err != nil {
-			return err
-		}
-		// configure tunnel
-		t := &Tunnel{
-			AppGuid:       appGuid,
-			TunnelAddr:    cfClient.Info.AppSshEndpoint,
-			TunnelHostKey: cfClient.Info.AppSshHostKey,
-			ForwardAddrs:  []ForwardAddrs{},
-			PasswordFunc:  cfClient.SSHCode,
-		}
-		// for each service instance
-		localPort := ConduitLocalPort
-		for _, name := range serviceInstanceNames {
-			bound := false
-			for serviceInstanceGuid, serviceInstance := range serviceInstances {
-				if name != serviceInstance.Name {
-					continue
-				}
-				// bind conduit app to service instance
-				status.Text("Binding", serviceInstance.Name)
-				logging.Debug("binding", serviceInstanceGuid, "to", appGuid)
-				creds, err := cfClient.BindService(appGuid, serviceInstanceGuid)
-				if err != nil {
-					return err
-				}
-				// configure the port forwarding
-				logging.Debug("creds", creds)
-				forwardAddr := ForwardAddrs{
-					LocalPort:   localPort,
-					RemoteAddr:  fmt.Sprintf("%s:%d", creds.Host, creds.Port),
-					Credentials: creds,
-				}
-				localPort++
 
-				// We need a TLS proxy for the following services which need an extra port
-				if name == "redis" {
-					forwardAddr.LocalTLSPort = localPort
-					localPort++
-				}
-
-				t.ForwardAddrs = append(t.ForwardAddrs, forwardAddr)
-
-				bound = true
-			}
-			if !bound {
-				return fmt.Errorf("failed to bind service: '%s' was not found in space '%s'", name, space.Name)
-			}
-		}
-		// fetch the full app env
-		status.Text("Fetching environment")
-		appEnv, err := cfClient.GetAppEnv(appGuid)
-		if err != nil {
+		if err := app.Init(); err != nil {
 			return err
-		}
-		// configure the environment
-		runenv := map[string]string{}
-		for serviceName, serviceInstances := range appEnv.SystemEnv.VcapServices {
-			for _, si := range serviceInstances {
-				// modify
-				si.Credentials.Host = "127.0.0.1"
-				si.Credentials.Port = localPort
-				switch serviceName {
-				case "postgres":
-					runenv["PGDATABASE"] = si.Credentials.Name
-					runenv["PGHOST"] = si.Credentials.Host
-					runenv["PGPORT"] = fmt.Sprintf("%d", si.Credentials.Port)
-					runenv["PGUSER"] = si.Credentials.Username
-					runenv["PGPASSWORD"] = si.Credentials.Password
-				case "mysql":
-					tmpdir, err := ioutil.TempDir("", "conduit")
-					if err != nil {
-						return err
-					}
-					defer os.RemoveAll(tmpdir)
-					mycnfPath := filepath.Join(tmpdir, "my.cnf")
-					mycnf := "[mysql]\n"
-					mycnf += fmt.Sprintf("user = %s\n", si.Credentials.Username)
-					mycnf += fmt.Sprintf("password = %s\n", si.Credentials.Password)
-					mycnf += fmt.Sprintf("host = %s\n", si.Credentials.Host)
-					mycnf += fmt.Sprintf("port = %d\n", si.Credentials.Port)
-					mycnf += fmt.Sprintf("database = %s\n", si.Credentials.Name)
-					mycnf += "[mysqldump]\n"
-					mycnf += fmt.Sprintf("user = %s\n", si.Credentials.Username)
-					mycnf += fmt.Sprintf("password = %s\n", si.Credentials.Password)
-					mycnf += fmt.Sprintf("host = 127.0.0.1\n")
-					mycnf += fmt.Sprintf("port = %d\n", localPort)
-					if err := ioutil.WriteFile(mycnfPath, []byte(mycnf), 0644); err != nil {
-						return fmt.Errorf("failed to create temporary mysql config: %s", err)
-					}
-					runenv["MYSQL_HOME"] = tmpdir
-				}
-			}
-		}
-		logging.Debug("runenv", runenv)
-		// poll for started state
-		status.Text("Waiting for conduit app to become available")
-		err = cfClient.PollForAppState(appGuid, "STARTED", 15)
-		if err != nil {
-			return err
-		}
-		// start the tunnel
-		status.Text("Starting port forwarding")
-		err = t.Start()
-		if err != nil {
-			return err
-		}
-		defer t.Stop()
-		// wait for port forwarding to become active
-		status.Text("Waiting for port forwarding")
-		for _, fwd := range t.ForwardAddrs {
-			select {
-			case err := <-waitForConnection(fwd.LocalAddress()):
-				if err != nil {
-					return err
-				}
-			case err := <-t.WaitChan():
-				if err != nil {
-					return err
-				}
-			}
 		}
 
-		// Start TLS proxies
-		for _, addr := range t.ForwardAddrs {
-			if addr.LocalTLSPort == 0 {
-				continue
-			}
+		if err := app.DeployApp(); err != nil {
+			return err
+		}
 
-			tlsTunnel := tls.NewTunnel(addr.LocalTLSAddress(), addr.LocalAddress())
-			_, err := tlsTunnel.Start()
-			if err != nil {
-				return err
-			}
-			err = <-waitForConnection(addr.LocalTLSAddress())
-			if err != nil {
-				return err
-			}
+		if err := app.SetupTunnels(); err != nil {
+			return err
 		}
 
 		status.Done()
-		// add modified VCAP_SERVICES to environment
-		if b, err := json.Marshal(appEnv.SystemEnv.VcapServices); err != nil {
-			return fmt.Errorf("failed to marshal VCAP_SERVICES: %s", err)
-		} else {
-			runenv["VCAP_SERVICES"] = string(b)
-			logging.Debug("VCAP_SERVICES", string(b))
-		}
-		// render message about ports
+
 		if logging.Verbose || len(runargs) == 0 {
-			t := template.Must(template.New("tunnelInfo").Parse(tunnelInfo))
-			var out bytes.Buffer
-			t.Execute(&out, appEnv.SystemEnv)
-			fmt.Fprintln(os.Stderr, out.String())
+			app.PrintConnectionInfo()
 		}
-		// execute CMD with enviornment
-		runargChan := make(chan struct{})
+
+		finish := make(chan struct{})
 		if len(runargs) > 0 {
-			status.Text("Preparing command:", runargs)
-			exe, err := exec.LookPath(runargs[0])
-			if err != nil {
-				return fmt.Errorf("cannot find '%s' in PATH", runargs[0])
+			if err := app.RunCommand(runargs, finish); err != nil {
+				return err
 			}
-			proc := exec.Command(exe, runargs[1:]...)
-			proc.Env = os.Environ()
-			for k, v := range runenv {
-				proc.Env = append(proc.Env, fmt.Sprintf("%s=%s", k, v))
-			}
-			proc.Stdout = os.Stdout
-			proc.Stdin = os.Stdin
-			proc.Stderr = os.Stderr
-			status.Done()
-			logging.Debug("running", runargs)
-			if err := proc.Start(); err != nil {
-				return fmt.Errorf("%s: %s", exe, err)
-			}
-			go func() {
-				defer close(runargChan)
-				proc.Wait()
-			}()
 		} else {
 			fmt.Fprintln(os.Stderr, "\n\nPress Ctrl+C to shutdown.")
 		}
+
 		// wait
 		select {
 		case <-shutdown:
 			return nil
-		case <-runargChan:
+		case <-finish:
 			return nil
 		}
 	},

--- a/conduit.go
+++ b/conduit.go
@@ -109,7 +109,7 @@ var ConnectService = &cobra.Command{
 				return err
 			}
 		} else {
-			fmt.Fprintln(os.Stderr, "\n\nPress Ctrl+C to shutdown.")
+			fmt.Fprintln(os.Stderr, "\nPress Ctrl+C to shutdown.")
 		}
 
 		// wait

--- a/conduit/app.go
+++ b/conduit/app.go
@@ -1,0 +1,391 @@
+package conduit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"os"
+	"os/exec"
+
+	"github.com/alphagov/paas-cf-conduit/client"
+	"github.com/alphagov/paas-cf-conduit/logging"
+	"github.com/alphagov/paas-cf-conduit/ssh"
+	"github.com/alphagov/paas-cf-conduit/tls"
+	"github.com/alphagov/paas-cf-conduit/util"
+	"github.com/cloudfoundry/multierror"
+)
+
+const tunnelInfo = `
+The following services are ready for you to connect to:
+
+{{range $serviceName, $services := .VcapServices}}
+	{{range $serviceIndex, $service := $services}}
+		service: {{$service.Name}} ({{$serviceName}})
+		host: {{$service.Credentials.Host}}
+		port: {{$service.Credentials.Port}}
+		username: {{$service.Credentials.Username}}
+		password: {{$service.Credentials.Password}}
+		db: {{$service.Credentials.Name}}
+	{{end}}
+{{end}}
+`
+
+type App struct {
+	cfClient             *client.Client
+	status               *util.Status
+	localPort            int64
+	orgName              string
+	spaceName            string
+	appName              string
+	deleteApp            bool
+	serviceInstanceNames []string
+	org                  *client.Org
+	space                *client.Space
+	appGUID              string
+	appEnv               *client.Env
+	serviceProviders     map[string]ServiceProvider
+	runEnv               map[string]string
+	forwardAddrs         []ssh.ForwardAddrs
+	tunnel               *ssh.Tunnel
+	tlsTunnels           []*tls.Tunnel
+}
+
+type ServiceProvider interface {
+	IsTLSEnabled(creds *client.Credentials) bool
+	InitEnv(creds *client.Credentials, env map[string]string) error
+	Teardown() error
+}
+
+func NewApp(
+	cfClient *client.Client,
+	status *util.Status,
+	localPort int64,
+	orgName string,
+	spaceName string,
+	appName string,
+	deleteApp bool,
+	serviceInstanceNames []string,
+) *App {
+	return &App{
+		cfClient:             cfClient,
+		status:               status,
+		localPort:            localPort,
+		orgName:              orgName,
+		spaceName:            spaceName,
+		appName:              appName,
+		deleteApp:            deleteApp,
+		serviceInstanceNames: serviceInstanceNames,
+		serviceProviders:     make(map[string]ServiceProvider),
+		runEnv:               make(map[string]string),
+		forwardAddrs:         make([]ssh.ForwardAddrs, 0),
+	}
+}
+
+func (a *App) RegisterServiceProvider(name string, serviceProvider ServiceProvider) {
+	a.serviceProviders[name] = serviceProvider
+}
+
+func (a *App) Init() error {
+	var err error
+	// get org
+	a.status.Text("Targeting org", a.orgName)
+	a.org, err = a.cfClient.GetOrgByName(a.orgName)
+	if err != nil {
+		return err
+	}
+	// get space
+	a.status.Text("Targeting space", a.spaceName)
+	a.space, err = a.cfClient.GetSpaceByName(a.org.Guid, a.spaceName)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *App) DeployApp() error {
+	if err := a.deployApp(); err != nil {
+		return err
+	}
+
+	if err := a.bindServices(); err != nil {
+		return err
+	}
+
+	if err := a.initServiceBindings(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *App) RunCommand(runargs []string, finish chan struct{}) error {
+	// execute CMD with environment
+	a.status.Text("Preparing command:", runargs)
+	exe, err := exec.LookPath(runargs[0])
+	if err != nil {
+		return fmt.Errorf("cannot find '%s' in PATH", runargs[0])
+	}
+	proc := exec.Command(exe, runargs[1:]...)
+	proc.Env = os.Environ()
+	for k, v := range a.runEnv {
+		proc.Env = append(proc.Env, fmt.Sprintf("%s=%s", k, v))
+	}
+	proc.Stdout = os.Stdout
+	proc.Stdin = os.Stdin
+	proc.Stderr = os.Stderr
+	a.status.Done()
+	logging.Debug("running", runargs)
+	if err := proc.Start(); err != nil {
+		return fmt.Errorf("%s: %s", exe, err)
+	}
+	go func() {
+		defer close(finish)
+		proc.Wait()
+	}()
+
+	return nil
+}
+
+func (a *App) deployApp() error {
+	var err error
+	a.status.Text("Deploying", a.appName)
+	a.appGUID, err = a.cfClient.CreateApp(a.appName, a.space.Guid)
+	if err != nil {
+		return err
+	}
+
+	// upload bits if not staged
+	a.status.Text("Uploading", a.appName, "bits")
+	if err := a.cfClient.UploadStaticAppBits(a.appGUID); err != nil {
+		return err
+	}
+	// start app
+	a.status.Text("Starting", a.appName)
+	if err := a.cfClient.UpdateApp(a.appGUID, map[string]interface{}{"state": "STARTED"}); err != nil {
+		return err
+	}
+
+	// poll for started state
+	a.status.Text("Waiting for conduit app to become available")
+	if err := a.cfClient.PollForAppState(a.appGUID, "STARTED", 15); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *App) destroyApp() error {
+	logging.Debug("destroying", a.appName, a.appGUID)
+	if err := a.cfClient.DestroyApp(a.appGUID); err != nil {
+		logging.Debug("failed to delete app", a.appName, "err:", err)
+
+		logging.Debug("refreshing auth token")
+		newToken, err := a.cfClient.GetNewAccessToken()
+		if err != nil {
+			logging.Debug("failed to get new access token, err:", err)
+			return fmt.Errorf("failed to delete %s app, please delete it manually\n", a.appName)
+		}
+		a.cfClient, err = client.NewClient(
+			a.cfClient.ApiEndpoint, newToken, a.cfClient.InsecureSkipVerify,
+		)
+		if err != nil {
+			logging.Debug("failed to create cf client with new access token, err:", err)
+			return fmt.Errorf("failed to delete %s app, please delete it manually\n", a.appName)
+		}
+
+		if err := a.cfClient.DestroyApp(a.appGUID); err != nil {
+			logging.Debug("failed to delete app", a.appName, "err:", err)
+			return fmt.Errorf("failed to delete %s app, please delete it manually\n", a.appName)
+		}
+	}
+	return nil
+}
+
+func (a *App) bindServices() error {
+	var err error
+	// get service instances
+	a.status.Text("Fetching service infomation")
+	serviceInstances, err := a.cfClient.GetServiceInstances(
+		fmt.Sprintf("space_guid:%s", a.space.Guid),
+	)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range a.serviceInstanceNames {
+		bound := false
+		for serviceInstanceGUID, serviceInstance := range serviceInstances {
+			if name != serviceInstance.Name {
+				continue
+			}
+			// bind conduit app to service instance
+			a.status.Text("Binding", serviceInstance.Name)
+			logging.Debug("binding", serviceInstanceGUID, "to", a.appGUID)
+			_, err := a.cfClient.BindService(a.appGUID, serviceInstanceGUID)
+			if err != nil {
+				return err
+			}
+			bound = true
+		}
+		if !bound {
+			return fmt.Errorf("failed to bind service: '%s' was not found in space '%s'", name, a.space.Name)
+		}
+	}
+
+	// fetch the full app env
+	a.status.Text("Fetching environment")
+	a.appEnv, err = a.cfClient.GetAppEnv(a.appGUID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *App) initServiceBindings() error {
+	port := a.localPort
+	for serviceName, serviceInstances := range a.appEnv.SystemEnv.VcapServices {
+		for _, si := range serviceInstances {
+			if serviceProvider, ok := a.serviceProviders[serviceName]; ok {
+				forwardAddr := ssh.ForwardAddrs{
+					RemoteAddr: fmt.Sprintf("%s:%d", si.Credentials.Host, si.Credentials.Port),
+					LocalPort:  port,
+				}
+				port++
+
+				if serviceName == "redis" {
+					forwardAddr.TLSTunnelPort = port
+					port++
+				}
+
+				a.forwardAddrs = append(a.forwardAddrs, forwardAddr)
+
+				si.Credentials.Host = "127.0.0.1"
+				si.Credentials.Port = forwardAddr.ConnectPort()
+
+				serviceProvider.InitEnv(si.Credentials, a.runEnv)
+			}
+		}
+	}
+
+	logging.Debug("runenv", a.runEnv)
+
+	// add modified VCAP_SERVICES to environment
+	if b, err := json.Marshal(a.appEnv.SystemEnv.VcapServices); err != nil {
+		return fmt.Errorf("failed to marshal VCAP_SERVICES: %s", err)
+	} else {
+		a.runEnv["VCAP_SERVICES"] = string(b)
+		logging.Debug("VCAP_SERVICES", string(b))
+	}
+
+	return nil
+}
+
+func (a *App) PrintConnectionInfo() {
+	// render message about ports
+	t := template.Must(template.New("tunnelInfo").Parse(tunnelInfo))
+	var out bytes.Buffer
+	t.Execute(&out, a.appEnv.SystemEnv)
+	fmt.Fprintln(os.Stderr, out.String())
+}
+
+func (a *App) SetupTunnels() error {
+	if err := a.startSSHTunnels(); err != nil {
+		return err
+	}
+
+	if err := a.startTLSTunnels(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *App) startSSHTunnels() error {
+	a.tunnel = &ssh.Tunnel{
+		AppGuid:       a.appGUID,
+		TunnelAddr:    a.cfClient.Info.AppSshEndpoint,
+		TunnelHostKey: a.cfClient.Info.AppSshHostKey,
+		ForwardAddrs:  a.forwardAddrs,
+		PasswordFunc:  a.cfClient.SSHCode,
+	}
+
+	// start the tunnel
+	a.status.Text("Starting port forwarding")
+	if err := a.tunnel.Start(); err != nil {
+		return err
+	}
+
+	// wait for port forwarding to become active
+	a.status.Text("Waiting for port forwarding")
+	for _, fwd := range a.tunnel.ForwardAddrs {
+		select {
+		case err := <-util.WaitForConnection(fwd.LocalAddress()):
+			if err != nil {
+				return err
+			}
+		case err := <-a.tunnel.WaitChan():
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (a *App) startTLSTunnels() error {
+	// Start TLS proxies
+	for _, addr := range a.forwardAddrs {
+		if addr.TLSTunnelPort == 0 {
+			continue
+		}
+
+		tlsTunnel := tls.NewTunnel(addr.TLSTunnelAddress(), addr.LocalAddress())
+		_, err := tlsTunnel.Start()
+		if err != nil {
+			return err
+		}
+		a.tlsTunnels = append(a.tlsTunnels, tlsTunnel)
+
+		err = <-util.WaitForConnection(addr.TLSTunnelAddress())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a *App) Teardown() error {
+	errs := &multierror.MultiError{}
+
+	for _, tlsTunnel := range a.tlsTunnels {
+		if err := tlsTunnel.Stop(); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	if a.tunnel != nil {
+		if err := a.tunnel.Stop(); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	for _, sp := range a.serviceProviders {
+		if err := sp.Teardown(); err != nil {
+			errs.Add(err)
+		}
+	}
+
+	if a.deleteApp && a.appGUID != "" {
+		if err := a.destroyApp(); err != nil {
+			errs.Add(err)
+		}
+	}
+	if len(errs.Errors) > 0 {
+		return errs
+	}
+	return nil
+}

--- a/conduit/app.go
+++ b/conduit/app.go
@@ -19,18 +19,14 @@ import (
 
 const tunnelInfo = `
 The following services are ready for you to connect to:
-
-{{range $serviceName, $services := .VcapServices}}
-	{{range $serviceIndex, $service := $services}}
-		service: {{$service.Name}} ({{$serviceName}})
-		host: {{$service.Credentials.Host}}
-		port: {{$service.Credentials.Port}}
-		username: {{$service.Credentials.Username}}
-		password: {{$service.Credentials.Password}}
-		db: {{$service.Credentials.Name}}
-	{{end}}
-{{end}}
-`
+{{range $serviceName, $services := .VcapServices}}{{range $serviceIndex, $service := $services}}
+  service: {{$service.Name}} ({{$serviceName}})
+  host: {{$service.Credentials.Host}}
+  port: {{$service.Credentials.Port}}
+  username: {{$service.Credentials.Username}}
+  password: {{$service.Credentials.Password}}
+  db: {{$service.Credentials.Name}}
+{{end}}{{end}}`
 
 type App struct {
 	cfClient             *client.Client

--- a/conduit/app.go
+++ b/conduit/app.go
@@ -247,8 +247,7 @@ func (a *App) initServiceBindings() error {
 
 				a.forwardAddrs = append(a.forwardAddrs, forwardAddr)
 
-				si.Credentials.Host = "127.0.0.1"
-				si.Credentials.Port = forwardAddr.ConnectPort()
+				si.Credentials.SetAddress("127.0.0.1", forwardAddr.ConnectPort())
 
 				serviceProvider.InitEnv(si.Credentials, a.runEnv)
 			}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -3,21 +3,18 @@ package logging
 import (
 	"fmt"
 	"os"
-	"time"
 )
 
 var (
 	Verbose bool
 )
 
-func Fatal(args ...interface{}) {
-	fmt.Fprintln(os.Stderr, args...)
-	time.Sleep(10 * time.Second)
-	os.Exit(1)
-}
-
 func Debug(args ...interface{}) {
 	if Verbose {
 		fmt.Fprintln(os.Stderr, args...)
 	}
+}
+
+func Error(args ...interface{}) {
+	fmt.Fprintln(os.Stderr, args...)
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"golang.org/x/crypto/ssh/terminal"
 
@@ -39,23 +38,6 @@ func init() {
 			log.Println("...shutting down")
 		}
 	}()
-}
-
-func retry(fn func() error) error {
-	delayBetweenRetries := 500 * time.Millisecond
-	maxRetries := 10
-	try := 0
-	for {
-		try++
-		err := fn()
-		if err == nil {
-			return nil
-		}
-		if try > maxRetries {
-			return err
-		}
-		time.Sleep(delayBetweenRetries)
-	}
 }
 
 func main() {

--- a/plugin.go
+++ b/plugin.go
@@ -62,7 +62,7 @@ func (p *Plugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,
-			Build: 4,
+			Build: 5,
 		},
 		MinCliVersion: plugin.VersionType{
 			Major: 6,

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alphagov/paas-cf-conduit/client"
+	"github.com/alphagov/paas-cf-conduit/logging"
+)
+
+type MySQL struct {
+	workDir    string
+	serviceCnt int
+}
+
+func (m *MySQL) IsTLSEnabled(creds *client.Credentials) bool {
+	return strings.Contains(creds.URI, "ssl=true") || strings.Contains(creds.JDBCURI, "ssl=true")
+}
+
+func (m *MySQL) InitEnv(creds *client.Credentials, env map[string]string) error {
+	// We will only set the configuration for the first service
+	if m.serviceCnt > 0 {
+		return nil
+	}
+
+	var err error
+	m.workDir, err = ioutil.TempDir("", "conduit")
+	if err != nil {
+		return err
+	}
+	mycnfPath := filepath.Join(m.workDir, "my.cnf")
+	mycnf := "[mysql]\n"
+	mycnf += fmt.Sprintf("user = %s\n", creds.Username)
+	mycnf += fmt.Sprintf("password = %s\n", creds.Password)
+	mycnf += fmt.Sprintf("host = %s\n", creds.Host)
+	mycnf += fmt.Sprintf("port = %d\n", creds.Port)
+	mycnf += fmt.Sprintf("database = %s\n", creds.Name)
+	mycnf += "[mysqldump]\n"
+	mycnf += fmt.Sprintf("user = %s\n", creds.Username)
+	mycnf += fmt.Sprintf("password = %s\n", creds.Password)
+	mycnf += fmt.Sprintf("host = %s\n", creds.Host)
+	mycnf += fmt.Sprintf("port = %d\n", creds.Port)
+	if err := ioutil.WriteFile(mycnfPath, []byte(mycnf), 0644); err != nil {
+		return fmt.Errorf("failed to create temporary mysql config: %s", err)
+	}
+	env["MYSQL_HOME"] = m.workDir
+	m.serviceCnt++
+
+	return nil
+}
+
+func (m *MySQL) Teardown() error {
+	if m.workDir != "" {
+		logging.Debug("deleting", m.workDir)
+		return os.RemoveAll(m.workDir)
+	}
+	return nil
+}

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -59,3 +59,7 @@ func (m *MySQL) Teardown() error {
 	}
 	return nil
 }
+
+func (m *MySQL) GetNonTLSClients() []string {
+	return []string{}
+}

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/alphagov/paas-cf-conduit/client"
 	"github.com/alphagov/paas-cf-conduit/logging"
@@ -16,11 +15,11 @@ type MySQL struct {
 	serviceCnt int
 }
 
-func (m *MySQL) IsTLSEnabled(creds *client.Credentials) bool {
-	return strings.Contains(creds.URI, "ssl=true") || strings.Contains(creds.JDBCURI, "ssl=true")
+func (m *MySQL) IsTLSEnabled(creds client.Credentials) bool {
+	return creds.IsTLSEnabled()
 }
 
-func (m *MySQL) InitEnv(creds *client.Credentials, env map[string]string) error {
+func (m *MySQL) InitEnv(creds client.Credentials, env map[string]string) error {
 	// We will only set the configuration for the first service
 	if m.serviceCnt > 0 {
 		return nil
@@ -33,16 +32,16 @@ func (m *MySQL) InitEnv(creds *client.Credentials, env map[string]string) error 
 	}
 	mycnfPath := filepath.Join(m.workDir, "my.cnf")
 	mycnf := "[mysql]\n"
-	mycnf += fmt.Sprintf("user = %s\n", creds.Username)
-	mycnf += fmt.Sprintf("password = %s\n", creds.Password)
-	mycnf += fmt.Sprintf("host = %s\n", creds.Host)
-	mycnf += fmt.Sprintf("port = %d\n", creds.Port)
-	mycnf += fmt.Sprintf("database = %s\n", creds.Name)
+	mycnf += fmt.Sprintf("user = %s\n", creds.Username())
+	mycnf += fmt.Sprintf("password = %s\n", creds.Password())
+	mycnf += fmt.Sprintf("host = %s\n", creds.Host())
+	mycnf += fmt.Sprintf("port = %d\n", creds.Port())
+	mycnf += fmt.Sprintf("database = %s\n", creds.Database())
 	mycnf += "[mysqldump]\n"
-	mycnf += fmt.Sprintf("user = %s\n", creds.Username)
-	mycnf += fmt.Sprintf("password = %s\n", creds.Password)
-	mycnf += fmt.Sprintf("host = %s\n", creds.Host)
-	mycnf += fmt.Sprintf("port = %d\n", creds.Port)
+	mycnf += fmt.Sprintf("user = %s\n", creds.Username())
+	mycnf += fmt.Sprintf("password = %s\n", creds.Password())
+	mycnf += fmt.Sprintf("host = %s\n", creds.Host())
+	mycnf += fmt.Sprintf("port = %d\n", creds.Port())
 	if err := ioutil.WriteFile(mycnfPath, []byte(mycnf), 0644); err != nil {
 		return fmt.Errorf("failed to create temporary mysql config: %s", err)
 	}

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -62,3 +62,7 @@ func (m *MySQL) Teardown() error {
 func (m *MySQL) GetNonTLSClients() []string {
 	return []string{}
 }
+
+func (m *MySQL) GetKnownClients() []string {
+	return []string{"mysql", "mysqldump"}
+}

--- a/service/postgres.go
+++ b/service/postgres.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alphagov/paas-cf-conduit/client"
+)
+
+type Postgres struct {
+	serviceCnt int
+}
+
+func (p *Postgres) IsTLSEnabled(creds *client.Credentials) bool {
+	return strings.Contains(creds.URI, "ssl=true") || strings.Contains(creds.JDBCURI, "ssl=true")
+}
+
+func (p *Postgres) InitEnv(creds *client.Credentials, env map[string]string) error {
+	// We will only set the configuration for the first service
+	if p.serviceCnt > 0 {
+		return nil
+	}
+
+	env["PGDATABASE"] = creds.Name
+	env["PGHOST"] = creds.Host
+	env["PGPORT"] = fmt.Sprintf("%d", creds.Port)
+	env["PGUSER"] = creds.Username
+	env["PGPASSWORD"] = creds.Password
+
+	p.serviceCnt++
+	return nil
+}
+
+func (p *Postgres) Teardown() error {
+	return nil
+}

--- a/service/postgres.go
+++ b/service/postgres.go
@@ -37,3 +37,7 @@ func (p *Postgres) Teardown() error {
 func (p *Postgres) GetNonTLSClients() []string {
 	return []string{}
 }
+
+func (p *Postgres) GetKnownClients() []string {
+	return []string{"psql", "pg_dump"}
+}

--- a/service/postgres.go
+++ b/service/postgres.go
@@ -34,3 +34,7 @@ func (p *Postgres) InitEnv(creds *client.Credentials, env map[string]string) err
 func (p *Postgres) Teardown() error {
 	return nil
 }
+
+func (p *Postgres) GetNonTLSClients() []string {
+	return []string{}
+}

--- a/service/postgres.go
+++ b/service/postgres.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/alphagov/paas-cf-conduit/client"
 )
@@ -11,21 +10,21 @@ type Postgres struct {
 	serviceCnt int
 }
 
-func (p *Postgres) IsTLSEnabled(creds *client.Credentials) bool {
-	return strings.Contains(creds.URI, "ssl=true") || strings.Contains(creds.JDBCURI, "ssl=true")
+func (p *Postgres) IsTLSEnabled(creds client.Credentials) bool {
+	return creds.IsTLSEnabled()
 }
 
-func (p *Postgres) InitEnv(creds *client.Credentials, env map[string]string) error {
+func (p *Postgres) InitEnv(creds client.Credentials, env map[string]string) error {
 	// We will only set the configuration for the first service
 	if p.serviceCnt > 0 {
 		return nil
 	}
 
-	env["PGDATABASE"] = creds.Name
-	env["PGHOST"] = creds.Host
-	env["PGPORT"] = fmt.Sprintf("%d", creds.Port)
-	env["PGUSER"] = creds.Username
-	env["PGPASSWORD"] = creds.Password
+	env["PGDATABASE"] = creds.Database()
+	env["PGHOST"] = creds.Host()
+	env["PGPORT"] = fmt.Sprintf("%d", creds.Port())
+	env["PGUSER"] = creds.Username()
+	env["PGPASSWORD"] = creds.Password()
 
 	p.serviceCnt++
 	return nil

--- a/service/redis.go
+++ b/service/redis.go
@@ -20,3 +20,7 @@ func (r *Redis) InitEnv(creds *client.Credentials, env map[string]string) error 
 func (r *Redis) Teardown() error {
 	return nil
 }
+
+func (r *Redis) GetNonTLSClients() []string {
+	return []string{"redis-cli"}
+}

--- a/service/redis.go
+++ b/service/redis.go
@@ -9,11 +9,11 @@ import (
 type Redis struct {
 }
 
-func (r *Redis) IsTLSEnabled(creds *client.Credentials) bool {
-	return strings.HasPrefix(creds.URI, "rediss")
+func (r *Redis) IsTLSEnabled(creds client.Credentials) bool {
+	return creds.IsTLSEnabled() || strings.HasPrefix(creds.URI(), "rediss")
 }
 
-func (r *Redis) InitEnv(creds *client.Credentials, env map[string]string) error {
+func (r *Redis) InitEnv(creds client.Credentials, env map[string]string) error {
 	return nil
 }
 

--- a/service/redis.go
+++ b/service/redis.go
@@ -24,3 +24,7 @@ func (r *Redis) Teardown() error {
 func (r *Redis) GetNonTLSClients() []string {
 	return []string{"redis-cli"}
 }
+
+func (r *Redis) GetKnownClients() []string {
+	return []string{"redis-cli"}
+}

--- a/service/redis.go
+++ b/service/redis.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/alphagov/paas-cf-conduit/client"
+)
+
+type Redis struct {
+}
+
+func (r *Redis) IsTLSEnabled(creds *client.Credentials) bool {
+	return strings.HasPrefix(creds.URI, "rediss")
+}
+
+func (r *Redis) InitEnv(creds *client.Credentials, env map[string]string) error {
+	return nil
+}
+
+func (r *Redis) Teardown() error {
+	return nil
+}

--- a/ssh/tunnel.go
+++ b/ssh/tunnel.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/alphagov/paas-cf-conduit/client"
 	"github.com/alphagov/paas-cf-conduit/logging"
 	"github.com/alphagov/paas-cf-conduit/util"
 
@@ -19,7 +18,6 @@ type ForwardAddrs struct {
 	LocalPort     int64
 	TLSTunnelPort int64
 	RemoteAddr    string
-	Credentials   *client.Credentials
 }
 
 func (f ForwardAddrs) LocalAddress() string {

--- a/tls/tunnel.go
+++ b/tls/tunnel.go
@@ -1,0 +1,79 @@
+package tls
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/alphagov/paas-cf-conduit/logging"
+)
+
+type Tunnel struct {
+	localAddr  string
+	remoteAddr string
+	listener   net.Listener
+	errorChan  chan error
+}
+
+func NewTunnel(localAddr, remoteAddr string) *Tunnel {
+	return &Tunnel{
+		localAddr:  localAddr,
+		remoteAddr: remoteAddr,
+		errorChan:  make(chan error, 8),
+	}
+}
+
+func (t *Tunnel) Start() (chan error, error) {
+	logging.Debug("starting TLS tunnel at", t.localAddr, "to", t.remoteAddr)
+	var err error
+	t.listener, err = net.Listen("tcp", t.localAddr)
+	if err != nil {
+		return nil, fmt.Errorf("starting a TLS tunnel failed: %s", err.Error())
+	}
+	go t.run()
+	return t.errorChan, nil
+}
+
+func (t *Tunnel) Stop() error {
+	return t.listener.Close()
+}
+
+func (t *Tunnel) run() {
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			t.errorChan <- fmt.Errorf("error accepting TLS connection: %s", err)
+			continue
+		}
+		logging.Debug("accepted TLS connection to", t.localAddr, "from", conn.RemoteAddr())
+		go func() {
+			err := t.handleRequest(conn)
+			if err != nil {
+				t.errorChan <- err
+			}
+		}()
+	}
+}
+
+func (t *Tunnel) handleRequest(conn net.Conn) error {
+	tlsConfig := tls.Config{
+		InsecureSkipVerify: true,
+	}
+	rconn, err := tls.Dial("tcp", t.remoteAddr, &tlsConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to %s: %s", t.remoteAddr, "err")
+	}
+
+	go t.forward(conn, rconn)
+	go t.forward(rconn, conn)
+
+	return nil
+}
+
+func (t *Tunnel) forward(dst, src net.Conn) {
+	_, err := io.Copy(dst, src)
+	if err != nil && err != io.EOF {
+		t.errorChan <- fmt.Errorf("failed to send data: %s", err)
+	}
+}

--- a/tunnel.go
+++ b/tunnel.go
@@ -15,9 +15,25 @@ import (
 )
 
 type ForwardAddrs struct {
-	LocalAddr   string
-	RemoteAddr  string
-	Credentials *client.Credentials
+	LocalPort    int64
+	LocalTLSPort int64
+	RemoteAddr   string
+	Credentials  *client.Credentials
+}
+
+func (f ForwardAddrs) LocalAddress() string {
+	return fmt.Sprintf("localhost:%d", f.LocalPort)
+}
+
+func (f ForwardAddrs) LocalTLSAddress() string {
+	return fmt.Sprintf("localhost:%d", f.LocalTLSPort)
+}
+
+func (f ForwardAddrs) ConnectAddress() string {
+	if f.LocalTLSPort != 0 {
+		return f.LocalTLSAddress()
+	}
+	return f.LocalAddress()
 }
 
 type Tunnel struct {
@@ -69,11 +85,11 @@ func (t *Tunnel) Start() error {
 }
 
 func (t *Tunnel) forward(fwd ForwardAddrs) (net.Listener, error) {
-	localListener, err := net.Listen("tcp", fwd.LocalAddr)
+	localListener, err := net.Listen("tcp", fwd.LocalAddress())
 	if err != nil {
 		return nil, err
 	}
-	logging.Debug("listening", fwd.LocalAddr)
+	logging.Debug("listening", fwd.LocalAddress())
 	go func() {
 		for {
 			localConn, err := localListener.Accept()

--- a/util/retry.go
+++ b/util/retry.go
@@ -1,0 +1,20 @@
+package util
+
+import "time"
+
+func Retry(fn func() error) error {
+	delayBetweenRetries := 500 * time.Millisecond
+	maxRetries := 10
+	try := 0
+	for {
+		try++
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if try > maxRetries {
+			return err
+		}
+		time.Sleep(delayBetweenRetries)
+	}
+}

--- a/util/status.go
+++ b/util/status.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"fmt"
@@ -12,18 +12,20 @@ import (
 	"github.com/fatih/color"
 )
 
-func NewStatus(w io.Writer) *Status {
+type Status struct {
+	spin           *spinner.Spinner
+	nonInteractive bool
+}
+
+func NewStatus(w io.Writer, nonInteractive bool) *Status {
 	s := &Status{
-		spin: spinner.New(spinner.CharSets[14], 250*time.Millisecond),
+		spin:           spinner.New(spinner.CharSets[14], 250*time.Millisecond),
+		nonInteractive: nonInteractive,
 	}
 	s.spin.Writer = os.Stderr
 	s.spin.Prefix = ""
 	s.spin.Suffix = ""
 	return s
-}
-
-type Status struct {
-	spin *spinner.Spinner
 }
 
 func (s *Status) Text(args ...interface{}) {
@@ -32,7 +34,7 @@ func (s *Status) Text(args ...interface{}) {
 	}
 	msg := fmt.Sprintln(args...)
 	msg = msg[:len(msg)-1]
-	if logging.Verbose || NonInteractive {
+	if logging.Verbose || s.nonInteractive {
 		logging.Debug(msg)
 	} else {
 		s.spin.Suffix = " " + msg

--- a/util/tcp.go
+++ b/util/tcp.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/alphagov/paas-cf-conduit/logging"
+)
+
+func WaitForConnection(addr string) chan error {
+	timeout := 3 * time.Second
+	connection := make(chan error)
+	go func() {
+		defer close(connection)
+		tries := 0
+		for {
+			if tries > 5 {
+				time.Sleep(2 * time.Second)
+			} else {
+				time.Sleep(1 * time.Second)
+			}
+			tries++
+			logging.Debug("waiting for", addr, "attempt", tries)
+			conn, err := net.DialTimeout("tcp", addr, timeout)
+			if err != nil {
+				if tries < 15 {
+					continue
+				}
+				connection <- fmt.Errorf("connection fail after %d attempts: %s", tries, err)
+				break
+			}
+			defer conn.Close()
+			connection <- nil
+			break
+		}
+	}()
+	return connection
+}

--- a/vendor/github.com/cloudfoundry/multierror/LICENSE
+++ b/vendor/github.com/cloudfoundry/multierror/LICENSE
@@ -1,0 +1,177 @@
+              Apache License
+           Version 2.0, January 2004
+        http://www.apache.org/licenses/
+
+		
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/vendor/github.com/cloudfoundry/multierror/NOTICE
+++ b/vendor/github.com/cloudfoundry/multierror/NOTICE
@@ -1,0 +1,13 @@
+Copyright (c) 2016-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/cloudfoundry/multierror/README.md
+++ b/vendor/github.com/cloudfoundry/multierror/README.md
@@ -1,0 +1,31 @@
+# Multierror
+
+`multierror` is a simple go package that allows you to combine and present multiple errors as a single error.
+
+# Installation
+Run `go get github.com/cloudfoundry/multierror`
+
+# How to use
+
+```go
+import "github.com/cloudfoundry/multierror"
+
+errors := multierror.MultiError{}
+
+err1 := FirstFuncThatReturnsError()
+err2 := SecondFuncThatReturnsError()
+
+errors.Add(err1)
+errors.Add(err2)
+
+//You can also add multierror structs and they will be flattened into one struct
+errors2 := multierror.MultiError()
+errors2.Add(err1)
+errors.Add(errors2)
+
+
+//Returns the errors as an aggregate of all the error messages
+errors.Error()
+```
+
+

--- a/vendor/github.com/cloudfoundry/multierror/multierror.go
+++ b/vendor/github.com/cloudfoundry/multierror/multierror.go
@@ -1,0 +1,88 @@
+package multierror
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+type MultiError struct {
+	Message string
+	Errors  []*MultiError
+	isError bool
+}
+
+func NewMultiError(message string) *MultiError {
+	return &MultiError{
+		Message: message,
+		Errors:  []*MultiError{},
+		isError: false,
+	}
+}
+
+func (m *MultiError) Add(e error) {
+	multierr, ok := e.(*MultiError)
+	if ok {
+		m.Errors = append(m.Errors, multierr)
+	} else {
+		leafError := NewMultiError(e.Error())
+		leafError.isError = true
+		m.Errors = append(m.Errors, leafError)
+	}
+}
+
+func (m *MultiError) isLeafNode() bool {
+	return m.isError && len(m.Errors) == 0
+}
+
+func (m *MultiError) Length() int {
+	if m.isLeafNode() {
+		return 1
+	}
+	var length int
+	for _, err := range m.Errors {
+		length += err.Length()
+	}
+	return length
+}
+
+func (m *MultiError) Error() string {
+	if m.Length() == 0 {
+		return "there were 0 errors"
+	}
+	return m.formatError(0)
+}
+
+func (m *MultiError) getMessage() string {
+	if m.isLeafNode() {
+		return fmt.Sprintf("* %s", m.Message)
+	}
+	var grammar string
+	if m.Length() == 1 {
+		grammar = "was 1 error"
+	} else {
+		grammar = fmt.Sprintf("were %d errors", m.Length())
+	}
+
+	msg := fmt.Sprintf("there %s", grammar)
+
+	if m.Message != "" {
+		msg = fmt.Sprintf("%s with '%s'", msg, m.Message)
+	}
+
+	return fmt.Sprintf("%s:", msg)
+}
+
+func (m *MultiError) formatError(indent int) string {
+	var buffer bytes.Buffer
+	for i := 0; i < indent; i++ {
+		buffer.WriteString("    ")
+	}
+	whitespace := buffer.String()
+	formattedMessage := strings.Replace(m.getMessage(), "\n", fmt.Sprintf("\n%s  ", whitespace), -1)
+	buffer.WriteString(fmt.Sprintf("%s\n", formattedMessage))
+	for _, elem := range m.Errors {
+		buffer.WriteString(elem.formatError(indent + 1))
+	}
+	return buffer.String()
+}

--- a/vendor/github.com/cloudfoundry/multierror/multierror_suite_test.go
+++ b/vendor/github.com/cloudfoundry/multierror/multierror_suite_test.go
@@ -1,0 +1,13 @@
+package multierror_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestMultierror(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Multierror Suite")
+}

--- a/vendor/github.com/cloudfoundry/multierror/multierror_test.go
+++ b/vendor/github.com/cloudfoundry/multierror/multierror_test.go
@@ -1,0 +1,182 @@
+package multierror_test
+
+import (
+	"fmt"
+
+	"code.cloudfoundry.org/multierror"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Multierror", func() {
+	var (
+		m *multierror.MultiError
+	)
+
+	BeforeEach(func() {
+		m = multierror.NewMultiError("top level field")
+	})
+
+	Describe("Add", func() {
+		Describe("adding a regular (non-MultiError) error", func() {
+			It("creates a multierror with an empty list, and adds the error", func() {
+				err := fmt.Errorf("Sample Error")
+				m.Add(err)
+				Expect(m.Length()).To(Equal(1))
+				Expect(m.Error()).To(ContainSubstring("Sample Error"))
+			})
+		})
+
+		Describe("adding a MultiError", func() {
+			It("adds all the errors", func() {
+				m.Add(fmt.Errorf("Error 1"))
+				m.Add(fmt.Errorf("Error 2"))
+				m2 := multierror.NewMultiError("inner field")
+				m2.Add(fmt.Errorf("Error 3"))
+				m2.Add(fmt.Errorf("Error 4"))
+				m.Add(m2)
+
+				Expect(m.Errors).To(ContainElement(m2))
+				Expect(m.Length()).To(Equal(4))
+			})
+		})
+	})
+
+	Describe("Length", func() {
+		Context("when the MultiError is a leaf node", func() {
+			BeforeEach(func() {
+				m.Add(fmt.Errorf("leaf error"))
+			})
+
+			It("returns 1", func() {
+				innerError := m.Errors[0]
+				Expect(innerError.Length()).To(Equal(1))
+			})
+		})
+
+		Context("when the MultiError is not a leaf node, but is empty", func() {
+			It("returns 0", func() {
+				Expect(m.Length()).To(Equal(0))
+			})
+		})
+
+		Context("when there are nested empty MultiErrors", func() {
+			BeforeEach(func() {
+				innerMostError := multierror.NewMultiError("innermost field")
+				innerError := multierror.NewMultiError("inner field")
+				innerError.Add(innerMostError)
+				m.Add(innerError)
+			})
+
+			It("returns 0", func() {
+				Expect(m.Length()).To(Equal(0))
+			})
+		})
+
+		Context("when the multi error contains sub-errors", func() {
+			BeforeEach(func() {
+				m.Add(fmt.Errorf("error 1"))
+				m.Add(fmt.Errorf("error 2"))
+				m.Add(fmt.Errorf("error 3"))
+			})
+
+			It("returns the number of sub-errors", func() {
+				Expect(m.Length()).To(Equal(3))
+			})
+
+			Context("when the sub-errors are MultiErrors", func() {
+				BeforeEach(func() {
+					nestedError := multierror.NewMultiError("inner field")
+					nestedError.Add(fmt.Errorf("inner error 1"))
+					nestedError.Add(fmt.Errorf("inner error 2"))
+					m.Add(nestedError)
+				})
+
+				It("includes the nested sub-errors in the length", func() {
+					Expect(m.Length()).To(Equal(5))
+				})
+			})
+		})
+	})
+
+	Describe("Error", func() {
+		Context("when multierrors are empty", func() {
+			It("should say there were 0 errors", func() {
+				Expect(m.Error()).To(ContainSubstring("there were 0 errors"))
+			})
+
+			Context("when there are nested multierrors but no actual errors", func() {
+				BeforeEach(func() {
+					m.Add(multierror.NewMultiError("another nested field"))
+				})
+				It("should say there were 0 errors", func() {
+					Expect(m.Error()).To(ContainSubstring("there were 0 errors"))
+				})
+			})
+		})
+
+		Context("when there are errors", func() {
+
+			Context("when the MultiError is a leaf node", func() {
+				BeforeEach(func() {
+					m.Add(fmt.Errorf("leaf error"))
+				})
+
+				It("returns a header with length plus the error message", func() {
+					innerError := m.Errors[0]
+					Expect(m.Error()).To(ContainSubstring("there was 1 error"))
+					Expect(m.Error()).To(ContainSubstring(innerError.Message))
+				})
+			})
+
+			Context("when there are nested errors", func() {
+				BeforeEach(func() {
+					cfErrors := multierror.NewMultiError("cf")
+					cfErrors.Add(fmt.Errorf("the file was blah"))
+					cfErrors.Add(fmt.Errorf("the thing was foo"))
+
+					stemcellErrors := multierror.NewMultiError("stemcell")
+					stemcellErrors.Add(fmt.Errorf("it stole my money"))
+
+					stubsErrors := multierror.NewMultiError("stubs")
+					stubsErrors.Add(fmt.Errorf("top level error for stubs occurred"))
+
+					stub1Errors := multierror.NewMultiError("stub \"my-stub-1\"")
+					stub1Errors.Add(fmt.Errorf("it never puts the toilet seat down"))
+					stub1Errors.Add(fmt.Errorf("it can't\n handle\n all these lines"))
+
+					stub2Errors := multierror.NewMultiError("stub \"my-stub-2\"")
+					stub2Errors.Add(fmt.Errorf("error 1"))
+					stub2Errors.Add(fmt.Errorf("error 2"))
+
+					stubsErrors.Add(stub1Errors)
+					stubsErrors.Add(stub2Errors)
+
+					m.Add(cfErrors)
+					m.Add(stemcellErrors)
+					m.Add(stubsErrors)
+				})
+
+				It("presents the nested-ness of the errors", func() {
+					Expect(m.Error()).To(ContainSubstring(`there were 8 errors with 'top level field'`))
+					Expect(m.Error()).To(ContainSubstring(`    there were 2 errors with 'cf':`))
+					Expect(m.Error()).To(ContainSubstring(`        * the file was blah`))
+					Expect(m.Error()).To(ContainSubstring(`        * the thing was foo`))
+					Expect(m.Error()).To(ContainSubstring(`    there was 1 error with 'stemcell':`))
+					Expect(m.Error()).To(ContainSubstring(`        * it stole my money`))
+					Expect(m.Error()).To(ContainSubstring(`    there were 5 errors with 'stubs':`))
+					Expect(m.Error()).To(ContainSubstring(`        * top level error for stubs occurred`))
+					Expect(m.Error()).To(ContainSubstring(`        there were 2 errors with 'stub "my-stub-1"':`))
+					Expect(m.Error()).To(ContainSubstring(`            * it never puts the toilet seat down`))
+					Expect(m.Error()).To(ContainSubstring(`            * it can't`))
+					Expect(m.Error()).To(ContainSubstring(`              handle`))
+					Expect(m.Error()).To(ContainSubstring(`              all these lines`))
+					Expect(m.Error()).To(ContainSubstring(`        there were 2 errors with 'stub "my-stub-2"':`))
+					Expect(m.Error()).To(ContainSubstring(`            * error 1`))
+					Expect(m.Error()).To(ContainSubstring(`            * error 2`))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
## What

I added support for Redis CLI.

Additional changes:
 - support for redis-cli (we add extra args to the redis-cli command to set host, port and password)
 - if the redis service is using TLS and the redis-cli program is used we start a TLS tunnel so a non-TLS enabled client, like redis-cli can connect
 - big refactor, all logic from the command was moved to a separate package and struct
 - several structs were moved to separate packages (out from main)
 - the credentials structure was changed to map[string]interface{} instead of a fix structure
 - all VCAP_SERVICES fields will be automatically updated with the local address

Bonus:
 - we check if a known application has a matching service type passed (so you get an error if you try to connect to a Postgres db with the mysql client), fixes https://github.com/alphagov/paas-cf-conduit/issues/32

❗️ Before merging bump the minor version in https://github.com/alphagov/paas-cf-conduit/blob/fbcbbf65c51c9945ce2b82d41735df3a818824e9/plugin.go#L65

## How to review

1. Create a service instance for all service types

```
cf create-service mysql Free mysql-test
cf create-service postgres Free postgres-test
cf create-service redis tiny-unclustered redis-test
```

1. Connect to all services with all known clients

```
cf conduit mysql-test -- mysql
cf conduit mysql-test -- mysqldump

cf conduit postgres-test -- psql
cf conduit postgres-test -- pgdump

cf conduit redis-test -- redis-cli
cf conduit redis-test -- redis-cli set foo bar
```

1. Check if connecting to the wrong service throws an error

```
cf conduit redis-test -- mysql
```

1. Check if all environment variables are properly set (all connection params should be updated with localhost and local port in VCAP_SERVICES)

```
cf conduit mysql-test -- env
cf conduit postgres-test -- env
cf conduit redis-test -- env
```

## Who can review

Not me.