### PR TITLE
Add ssh keepalive to stop servers from hanging up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 paas-cf-plugin
 bin
+/.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,57 +2,74 @@
 
 
 [[projects]]
+  digest = "1:4a32339f7f55c86c3a929c73e12dcaac481adaea9bcfb52638bcad484372cca2"
   name = "code.cloudfoundry.org/cli"
   packages = [
     "plugin",
-    "plugin/models"
+    "plugin/models",
   ]
+  pruneopts = ""
   revision = "829c87ef317ad6be9d73039934b9f1d82560c403"
   version = "v6.32.0"
 
 [[projects]]
+  digest = "1:3fc9b0f7d3cf0fd57264f4f092c6e6b443bf9a5d9ce1d9deb4849ab02ffe1878"
   name = "github.com/briandowns/spinner"
   packages = ["."]
+  pruneopts = ""
   revision = "48dbb65d7bd5c74ab50d53d04c949f20e3d14944"
   version = "1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d350098b4b6caae6e3657e6c7ee2f373cb4b1b47fa6302189967d57c5150ce59"
   name = "github.com/cloudfoundry/multierror"
   packages = ["."]
+  pruneopts = ""
   revision = "dafed03eebc65cdf3de2928e3f94793bc893ede0"
 
 [[projects]]
+  digest = "1:c9bebdae4ac52d0c3bbe5876de3d72f3bb05b4986865cdb3f15e305e1dc4fbca"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = ""
   revision = "570b54cabe6b8eb0bc2dfce68d964677d63b5260"
   version = "v1.5.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:54859951ba785c9f5c7a0e665a9fe9fb6b1afeef112c62eaad77081d3d5916cc"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = ""
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:78229b46ddb7434f881390029bd1af7661294af31f6802e0e1bedaad4ab0af3c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = ""
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:32b27072cd55bd2fb7244de0425943d125da6a552ae2b6517cdd965a662baf18"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -72,12 +89,14 @@
     "reporters/stenographer",
     "reporters/stenographer/support/go-colorable",
     "reporters/stenographer/support/go-isatty",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "9eda700730cba42af70d53180f9dcce9266bc2bc"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:a4e59d0b2821c983b58c317f141cd77df20570979632da8a7a352e5d12698de7"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -91,67 +110,81 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types"
+    "types",
   ]
+  pruneopts = ""
   revision = "c893efa28eb45626cdaa76c9f653b62488858837"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:2208a80fc3259291e43b30f42f844d18f4218036dff510f42c653ec9890d460a"
   name = "github.com/spf13/cobra"
   packages = ["."]
+  pruneopts = ""
   revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:261bc565833ef4f02121450d74eb88d5ae4bd74bfe5d0e862cddb8550ec35000"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = ""
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c0ceab2eace6862590fd85f8356b4fff8a5c40ab167c2518943361f93bc39b4f"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
     "ssh",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = ""
   revision = "ca1fcd4ab4c10bc58852a894bcf195fab2229efe"
 
 [[projects]]
   branch = "master"
+  digest = "1:380a633fea75037d4c51ccfab9bdd77cd0d9ecaf2c01fbcd4b07cfa23fc49a8d"
   name = "golang.org/x/net"
   packages = [
     "context",
     "context/ctxhttp",
     "html",
     "html/atom",
-    "html/charset"
+    "html/charset",
   ]
+  pruneopts = ""
   revision = "01c190206fbdffa42f334f4b2bf2220f50e64920"
 
 [[projects]]
   branch = "master"
+  digest = "1:3607c401db83333983b982a42f9871b6836d67fcf42e26385abd2f9781e48e1b"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
+  pruneopts = ""
   revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
 
 [[projects]]
   branch = "master"
+  digest = "1:7ab6e4d67d2aef1ea5c1f544e9c8f972f8c82f6e9ca58c49f844f60e4c30f0d9"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = ""
   revision = "8eb05f94d449fdf134ec24630ce69ada5b469c1c"
 
 [[projects]]
   branch = "master"
+  digest = "1:39a1a71adca4b837a25dc6b5fcdd9d175e4597c6d3440f107dfeda31230218e4"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -170,11 +203,13 @@
     "language",
     "runes",
     "transform",
-    "unicode/cldr"
+    "unicode/cldr",
   ]
+  pruneopts = ""
   revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
+  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -183,20 +218,34 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = ""
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "v2"
+  digest = "1:f769ed60e075e4221612c2f4162fccc9d3795ef358fa463425e3b3d7a5debb27"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c494ddcd5c195d250540d5954714c084294fe899d7d289022fdbb606743baddd"
+  input-imports = [
+    "code.cloudfoundry.org/cli/plugin",
+    "github.com/briandowns/spinner",
+    "github.com/cloudfoundry/multierror",
+    "github.com/fatih/color",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
+    "github.com/spf13/cobra",
+    "golang.org/x/crypto/ssh",
+    "golang.org/x/crypto/ssh/terminal",
+    "golang.org/x/oauth2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ssh/tunnel.go
+++ b/ssh/tunnel.go
@@ -21,6 +21,8 @@ type ForwardAddrs struct {
 	RemoteAddr    string
 }
 
+const keepaliveName = "keepalive@github.com/alphagov/paas-cf-conduit"
+
 func (f ForwardAddrs) LocalAddress() string {
 	return fmt.Sprintf("localhost:%d", f.LocalPort)
 }
@@ -184,7 +186,6 @@ func (t *Tunnel) startKeepalive(user string, sshConnection *ssh.Client) {
 	defer ticker.Stop()
 	for {
 		<-ticker.C
-		keepaliveName := "keepalive@github.com/alphagov/paas-cf-conduit"
 		if _, _, err := sshConnection.SendRequest(keepaliveName, true, nil); err != nil {
 			logging.Debug("failed to send keepalive message", user, t.TunnelAddr)
 			return

--- a/ssh/tunnel.go
+++ b/ssh/tunnel.go
@@ -180,7 +180,7 @@ func (t *Tunnel) Stop() error {
 }
 
 func (t *Tunnel) startKeepalive(user string, sshConnection *ssh.Client) {
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 	for {
 		<-ticker.C


### PR DESCRIPTION
Fixes #35 

What
----

As per [alphagov/paas-cf-conduit#35](https://github.com/alphagov/paas-cf-conduit/issues/35)
`cf conduit` doesn't send any keepalive packets. This means if both the
client and the server are idle, the server may decide that the client
has gone away and close the connection.

Adding a background loop that sends an empty packet over the ssh
connection every (hardcoded for now) 2 seconds prevents this.

I've tested this manually by connecting to `pgcli` to a postgres
database and then ignoring it for 10 mins - this used to result in
confusing hanging behaviour and weird errors, with these changes it
doesn't.

To be consistent with the rest of this codebase I haven't written any
tests.

Why
---

So `cf conduit` is more useful for tasks that might not have any traffic for
long periods of time (e.g. interactive processes or scripts with long running
steps).

How to review
-------------

* Code review
* Checkout the branch and `make install`, then manually test that `cf conduit` still works :trollface:
* Use `cf conduit` to connect to something, leave it for 10 mins, observe it still works