### PR TITLE
Use exit code from child process

### DIFF
--- a/conduit.go
+++ b/conduit.go
@@ -103,20 +103,15 @@ var ConnectService = &cobra.Command{
 			app.PrintConnectionInfo()
 		}
 
-		finish := make(chan struct{})
 		if len(runargs) > 0 {
-			if err := app.RunCommand(finish); err != nil {
-				return err
-			}
-		} else {
-			fmt.Fprintln(os.Stderr, "\nPress Ctrl+C to shutdown.")
+			return app.RunCommand()
 		}
+
+		fmt.Fprintln(os.Stderr, "\nPress Ctrl+C to shutdown.")
 
 		// wait
 		select {
 		case <-shutdown:
-			return nil
-		case <-finish:
 			return nil
 		}
 	},

--- a/plugin.go
+++ b/plugin.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"code.cloudfoundry.org/cli/plugin"
+
+	"github.com/alphagov/paas-cf-conduit/conduit"
 )
 
 type Plugin struct {
@@ -51,7 +53,12 @@ func (p *Plugin) Run(conn plugin.CliConnection, args []string) {
 	p.cmd.SetArgs(args)
 	if err := p.cmd.Execute(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+
+		if exitError, ok := err.(conduit.AppExecution); ok {
+			os.Exit(exitError.ExitCode)
+		} else {
+			os.Exit(1)
+		}
 	}
 	os.Exit(0)
 }


### PR DESCRIPTION
What
----

Fixes #44

Instead of using an empty channel and never reporting the exit code, actually pass the exit code back.

How to review
----

Code review

If this is good to merge then I will do the release dance

Who can review
----

Not @tlwr