### PR TITLE
Verbose keepalive logging; port in-use pre-flight checks

### DIFF
--- a/conduit.go
+++ b/conduit.go
@@ -69,6 +69,10 @@ var ConnectService = &cobra.Command{
 			return err
 		}
 
+		if util.PortIsInUse(int(ConduitLocalPort)) {
+			return fmt.Errorf("Port %d is already in use", ConduitLocalPort)
+		}
+
 		app := conduit.NewApp(
 			cfClient, status,
 			ConduitLocalPort, ConduitOrg, ConduitSpace, ConduitAppName, !ConduitReuse,

--- a/ssh/tunnel.go
+++ b/ssh/tunnel.go
@@ -185,8 +185,8 @@ func (t *Tunnel) startKeepalive(user string, sshConnection *ssh.Client) {
 	defer ticker.Stop()
 	for {
 		<-ticker.C
-		if _, _, err := sshConnection.SendRequest(keepaliveName, true, nil); err != nil {
-			logging.Debug("failed to send keepalive message", user, t.TunnelAddr)
+		if _, _, err := sshConnection.SendRequest(keepaliveName, true, make([]byte, 0)); err != nil {
+			logging.Debug("failed to send keepalive message", user, t.TunnelAddr, err)
 			return
 		}
 	}

--- a/util/port.go
+++ b/util/port.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+func PortIsInUse(port int) bool {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+
+	if listener != nil {
+		listener.Close()
+	}
+
+	if err == nil {
+		// port is not in use, because we could listen on it
+		return false
+	}
+
+	return true
+}
+
+func GetRandomPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+
+	if err != nil {
+		return 0, err
+	}
+
+	defer listener.Close()
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return 0, err
+	}
+
+	return strconv.Atoi(port)
+}

--- a/util/port_test.go
+++ b/util/port_test.go
@@ -1,0 +1,45 @@
+package util_test
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/alphagov/paas-cf-conduit/util"
+)
+
+var _ = Describe("PortIsInUse", func() {
+	var (
+		err      error
+		port     int
+		listener net.Listener
+	)
+
+	BeforeEach(func() {
+		port, err = util.GetRandomPort()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when the port is in use", func() {
+		BeforeEach(func() {
+			listener, err = net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			listener.Close()
+		})
+
+		It("should return true", func() {
+			Expect(util.PortIsInUse(port)).To(Equal(true))
+		})
+	})
+
+	Context("when the port is not in use", func() {
+		It("should return false", func() {
+			Expect(util.PortIsInUse(port)).To(Equal(false))
+		})
+	})
+})

--- a/util/util_suite_test.go
+++ b/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}


### PR DESCRIPTION
Log the keepalive error message
> As a user using the `--verbose` flag, I want to see the error causing keepalives to not be sent

Check that the port is free to use before starting
> As a user I want conduit to tell me when it is not able to start, due to the port being used.

---

See https://govuk.zendesk.com/agent/tickets/4084516