### PR TITLE
Add bind parameters argument

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -125,7 +125,11 @@ func (c *Client) GetServiceInstances(filters ...string) (map[string]*gocfclient.
 	return svcInstanceMap, nil
 }
 
-func (c *Client) BindService(appGuid string, serviceInstanceGuid string) (Credentials, error) {
+func (c *Client) BindService(
+	appGuid string,
+	serviceInstanceGuid string,
+	parameters map[string]interface{},
+) (Credentials, error) {
 	res := struct {
 		Entity struct {
 			Credentials credentials `json:"credentials"`
@@ -135,6 +139,7 @@ func (c *Client) BindService(appGuid string, serviceInstanceGuid string) (Creden
 	body := map[string]interface{}{
 		"app_guid":              appGuid,
 		"service_instance_guid": serviceInstanceGuid,
+		"parameters":            parameters,
 	}
 	bodyJson, err := json.Marshal(body)
 	if err != nil {

--- a/conduit.go
+++ b/conduit.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -73,10 +74,15 @@ var ConnectService = &cobra.Command{
 			return fmt.Errorf("Port %d is already in use", ConduitLocalPort)
 		}
 
+		var bindParams map[string]interface{}
+		if err = json.Unmarshal([]byte(RawBindParameters), &bindParams); err != nil {
+			return fmt.Errorf("Could not parse bind parameters as JSON: %s", err)
+		}
+
 		app := conduit.NewApp(
 			cfClient, status,
 			ConduitLocalPort, ConduitOrg, ConduitSpace, ConduitAppName, !ConduitReuse,
-			serviceInstanceNames, runargs,
+			serviceInstanceNames, runargs, bindParams,
 		)
 
 		app.RegisterServiceProvider("mysql", &service.MySQL{})

--- a/conduit/app.go
+++ b/conduit/app.go
@@ -32,6 +32,7 @@ type App struct {
 	orgName              string
 	spaceName            string
 	appName              string
+	bindParameters       map[string]interface{}
 	deleteApp            bool
 	serviceInstanceNames []string
 	runArgs              []string
@@ -65,6 +66,7 @@ func NewApp(
 	deleteApp bool,
 	serviceInstanceNames []string,
 	runArgs []string,
+	bindParameters map[string]interface{},
 ) *App {
 	var program string
 	if len(runArgs) > 0 {
@@ -84,6 +86,7 @@ func NewApp(
 		serviceProviders:     make(map[string]ServiceProvider),
 		runEnv:               make(map[string]string),
 		forwardAddrs:         make([]ssh.ForwardAddrs, 0),
+		bindParameters:       bindParameters,
 	}
 }
 
@@ -203,7 +206,7 @@ func (a *App) bindServices() error {
 			// bind conduit app to service instance
 			a.status.Text("Binding", serviceInstance.Name)
 			logging.Debug("binding", serviceInstanceGUID, "to", a.appGUID)
-			creds, err := a.cfClient.BindService(a.appGUID, serviceInstanceGUID)
+			creds, err := a.cfClient.BindService(a.appGUID, serviceInstanceGUID, a.bindParameters)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -17,16 +17,17 @@ import (
 )
 
 var (
-	NonInteractive   bool
-	ConduitReuse     bool
-	ConduitAppName   string
-	ConduitOrg       string
-	ConduitSpace     string
-	ConduitLocalPort int64
-	ApiEndpoint      string
-	ApiToken         string
-	ApiInsecure      bool
-	shutdown         chan struct{}
+	NonInteractive    bool
+	ConduitReuse      bool
+	ConduitAppName    string
+	ConduitOrg        string
+	ConduitSpace      string
+	ConduitLocalPort  int64
+	ApiEndpoint       string
+	ApiToken          string
+	ApiInsecure       bool
+	RawBindParameters string
+	shutdown          chan struct{}
 )
 
 func init() {
@@ -79,6 +80,7 @@ func main() {
 	cmd.PersistentFlags().MarkHidden("token")
 	cmd.PersistentFlags().BoolVar(&ApiInsecure, "insecure", false, "allow insecure API endpoint")
 	cmd.PersistentFlags().MarkHidden("insecure")
+	cmd.PersistentFlags().StringVarP(&RawBindParameters, "bind-parameters", "c", "{}", "bind parameters in JSON format")
 	cmd.AddCommand(ConnectService)
 	cmd.AddCommand(Uninstall)
 	plugin.Start(&Plugin{cmd})


### PR DESCRIPTION
# What

As a user,
I want to be able to specify bind parameters for my conduit app binding,
So that i can use the read only binding feature of the RDS broker

# How I'm using it

```
cf conduit billing-db -c '{ "read_only": true }' -- psql
```