### PR TITLE
Enable InfluxDB integration

### DIFF
--- a/conduit.go
+++ b/conduit.go
@@ -88,6 +88,7 @@ var ConnectService = &cobra.Command{
 		app.RegisterServiceProvider("mysql", &service.MySQL{})
 		app.RegisterServiceProvider("postgres", &service.Postgres{})
 		app.RegisterServiceProvider("redis", &service.Redis{})
+		app.RegisterServiceProvider("influxdb", &service.InfluxDB{})
 
 		defer func() {
 			if err := app.Teardown(); err != nil {

--- a/service/influxdb.go
+++ b/service/influxdb.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"fmt"
+	"github.com/alphagov/paas-cf-conduit/client"
+)
+
+type InfluxDB struct {
+}
+
+func (i InfluxDB) IsTLSEnabled(creds client.Credentials) bool {
+	return false
+	//return creds.IsTLSEnabled()
+}
+
+func (i InfluxDB) GetNonTLSClients() []string {
+	return []string{}
+}
+
+func (i InfluxDB) GetKnownClients() []string {
+	return []string{"influx", "chronograf", "telegraf", "influx_inspect", "inch"}
+}
+
+func (i InfluxDB) InitEnv(creds client.Credentials, env map[string]string) error {
+	env["INFLUX_USERNAME"] = creds.Username()
+	env["INFLUX_PASSWORD"] = creds.Password()
+	return nil
+}
+
+func (i InfluxDB) Teardown() error {
+	return nil
+}
+
+func (i InfluxDB) AdditionalProgramArgs(serviceInstances []*client.VcapService) []string {
+	if len(serviceInstances) == 0 {
+		return []string{}
+	}
+
+	return []string{
+		"-host", serviceInstances[0].Credentials.Host(),
+		"-port", fmt.Sprintf("%d", serviceInstances[0].Credentials.Port()),
+		"-database", serviceInstances[0].Credentials.Database(),
+		"-ssl",
+		
+		// Must be unsafe SSL, because the certificate presented by the Influx server
+		// does not have 127.0.0.1 as a Subject Alternative Name
+		"-unsafeSsl",
+	}
+}

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -66,3 +66,7 @@ func (m *MySQL) GetNonTLSClients() []string {
 func (m *MySQL) GetKnownClients() []string {
 	return []string{"mysql", "mysqldump"}
 }
+
+func (m *MySQL) AdditionalProgramArgs(serviceInstances []*client.VcapService) []string {
+	return []string{}
+}

--- a/service/postgres.go
+++ b/service/postgres.go
@@ -41,3 +41,7 @@ func (p *Postgres) GetNonTLSClients() []string {
 func (p *Postgres) GetKnownClients() []string {
 	return []string{"psql", "pg_dump"}
 }
+
+func (p *Postgres) AdditionalProgramArgs(serviceInstances []*client.VcapService) []string {
+	return []string{}
+}

--- a/service/redis.go
+++ b/service/redis.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/alphagov/paas-cf-conduit/client"
@@ -27,4 +28,16 @@ func (r *Redis) GetNonTLSClients() []string {
 
 func (r *Redis) GetKnownClients() []string {
 	return []string{"redis-cli"}
+}
+
+func (r *Redis) AdditionalProgramArgs(serviceInstances []*client.VcapService) []string {
+	if len(serviceInstances) == 0 {
+		return []string{}
+	}
+
+	return []string{
+		"-h", serviceInstances[0].Credentials.Host(),
+		"-p", fmt.Sprintf("%d", serviceInstances[0].Credentials.Port()),
+		"-a", serviceInstances[0].Credentials.Password(),
+	}
 }


### PR DESCRIPTION
What
---

Adds a new ServiceProvider implementation that handles InfluxDB connections.

Also refactors slightly to allow service providers to augment the command being run by the user, to automatically include extra flags that are necessary but that the user couldn't include themselves ahead of time (e.g. port, username)

How to review
--- 
1. Code review
1. @saliceti has tested the functionality, but we should test it as well:
    1. Install Influx CLI v1.x (v2 is _not_ compatible)
    1. Create a new InfluxDB service instance
    1. Install the plugin from source with `make install`
    1. `cf conduit SERVICE_INSTANCE_NAME -- influx`
    1. Run some Influx commands to make sure it all works
    1. Run `cf conduiit SERVICE_INSTANCE_NAME -- influx -execute 'COMMAND'` to check one-off commands can be run
