### PR TITLE
[#177494650] Add tls options with sensible secure defaults

### DIFF
--- a/conduit.go
+++ b/conduit.go
@@ -63,9 +63,19 @@ var ConnectService = &cobra.Command{
 		status := util.NewStatus(os.Stderr, NonInteractive)
 		defer status.Done()
 
+		tlsCipherSuites, err := util.CipherSuiteNamesToIDs(CipherSuites)
+		if err != nil {
+			return err
+		}
+
+		versionID, err := util.TLSVersionToID(MinTLSVersion)
+		if err != nil {
+			return err
+		}
+
 		// create a client
 		status.Text("Connecting client")
-		cfClient, err := client.NewClient(ApiEndpoint, ApiToken, ApiInsecure)
+		cfClient, err := client.NewClient(ApiEndpoint, ApiToken, ApiInsecure, tlsCipherSuites, versionID)
 		if err != nil {
 			return err
 		}
@@ -82,7 +92,7 @@ var ConnectService = &cobra.Command{
 		app := conduit.NewApp(
 			cfClient, status,
 			ConduitLocalPort, ConduitOrg, ConduitSpace, ConduitAppName, !ConduitReuse,
-			serviceInstanceNames, runargs, bindParams,
+			serviceInstanceNames, runargs, bindParams, ApiInsecure, tlsCipherSuites, versionID,
 		)
 
 		app.RegisterServiceProvider("mysql", &service.MySQL{})

--- a/plugin.go
+++ b/plugin.go
@@ -57,7 +57,6 @@ func (p *Plugin) Run(conn plugin.CliConnection, args []string) {
 			exitCode = exitError.ExitCode
 		}
 
-		fmt.Println(err)
 		os.Exit(exitCode)
 	}
 
@@ -70,7 +69,7 @@ func (p *Plugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,
-			Build: 14,
+			Build: 15,
 		},
 		MinCliVersion: plugin.VersionType{
 			Major: 6,

--- a/util/testdata/certs.pem
+++ b/util/testdata/certs.pem
@@ -1,0 +1,94 @@
+=== /C=CH/O=WISeKey/OU=OISTE Foundation Endorsed/CN=OISTE WISeKey Global Root GC CA
+Certificate:
+	Data:
+		Version: 3 (0x2)
+		Serial Number:
+			21:2a:56:0c:ae:da:0c:ab:40:45:bf:2b:a2:2d:3a:ea
+	Signature Algorithm: ecdsa-with-SHA384
+		Validity
+			Not Before: May  9 09:48:34 2017 GMT
+			Not After : May  9 09:58:33 2042 GMT
+		Subject: C=CH, O=WISeKey, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GC CA
+		X509v3 extensions:
+			X509v3 Key Usage: critical
+				Certificate Sign, CRL Sign
+			X509v3 Basic Constraints: critical
+				CA:TRUE
+			X509v3 Subject Key Identifier: 
+				48:87:14:AC:E3:C3:9E:90:60:3A:D7:CA:89:EE:D3:AD:8C:B4:50:66
+			1.3.6.1.4.1.311.21.1: 
+				...
+SHA1 Fingerprint=E0:11:84:5E:34:DE:BE:88:81:B9:9C:F6:16:26:D1:96:1F:C3:B9:31
+SHA256 Fingerprint=85:60:F9:1C:36:24:DA:BA:95:70:B5:FE:A0:DB:E3:6F:F1:1A:83:23:BE:94:86:85:4F:B3:F3:4A:55:71:19:8D
+-----BEGIN CERTIFICATE-----
+MIICaTCCAe+gAwIBAgIQISpWDK7aDKtARb8roi066jAKBggqhkjOPQQDAzBtMQsw
+CQYDVQQGEwJDSDEQMA4GA1UEChMHV0lTZUtleTEiMCAGA1UECxMZT0lTVEUgRm91
+bmRhdGlvbiBFbmRvcnNlZDEoMCYGA1UEAxMfT0lTVEUgV0lTZUtleSBHbG9iYWwg
+Um9vdCBHQyBDQTAeFw0xNzA1MDkwOTQ4MzRaFw00MjA1MDkwOTU4MzNaMG0xCzAJ
+BgNVBAYTAkNIMRAwDgYDVQQKEwdXSVNlS2V5MSIwIAYDVQQLExlPSVNURSBGb3Vu
+ZGF0aW9uIEVuZG9yc2VkMSgwJgYDVQQDEx9PSVNURSBXSVNlS2V5IEdsb2JhbCBS
+b290IEdDIENBMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAETOlQwMYPchi82PG6s4ni
+eUqjFqdrVCTbUf/q9Akkwwsin8tqJ4KBDdLArzHkdIJuyiXZjHWd8dvQmqJLIX4W
+p2OQ0jnUsYd4XxiWD1AbNTcPasbc2RNNpI6QN+a9WzGRo1QwUjAOBgNVHQ8BAf8E
+BAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUSIcUrOPDnpBgOtfKie7T
+rYy0UGYwEAYJKwYBBAGCNxUBBAMCAQAwCgYIKoZIzj0EAwMDaAAwZQIwJsdpW9zV
+57LnyAyMjMPdeYwbY9XJUpROTYJKcx6ygISpJcBMWm1JKWB4E+J+SOtkAjEA2zQg
+Mgj/mkkCtojeFK9dbJlxjRo/i9fgojaGHAeCOnZT/cKi7e97sIBPWA9LUzm9
+-----END CERTIFICATE-----
+
+### XRamp Security Services Inc
+
+=== /C=US/OU=www.xrampsecurity.com/O=XRamp Security Services Inc/CN=XRamp Global Certification Authority
+Certificate:
+	Data:
+		Version: 3 (0x2)
+		Serial Number:
+			50:94:6c:ec:18:ea:d5:9c:4d:d5:97:ef:75:8f:a0:ad
+	Signature Algorithm: sha1WithRSAEncryption
+		Validity
+			Not Before: Nov  1 17:14:04 2004 GMT
+			Not After : Jan  1 05:37:19 2035 GMT
+		Subject: C=US, OU=www.xrampsecurity.com, O=XRamp Security Services Inc, CN=XRamp Global Certification Authority
+		X509v3 extensions:
+			1.3.6.1.4.1.311.20.2: 
+				...C.A
+			X509v3 Key Usage: 
+				Digital Signature, Certificate Sign, CRL Sign
+			X509v3 Basic Constraints: critical
+				CA:TRUE
+			X509v3 Subject Key Identifier:
+				C6:4F:A2:3D:06:63:84:09:9C:CE:62:E4:04:AC:8D:5C:B5:E9:B6:1B
+			X509v3 CRL Distribution Points: 
+
+				Full Name:
+					URI:http://crl.xrampsecurity.com/XGCA.crl
+
+			1.3.6.1.4.1.311.21.1:
+				...
+SHA1 Fingerprint=B8:01:86:D1:EB:9C:86:A5:41:04:CF:30:54:F3:4C:52:B7:E5:58:C6
+SHA256 Fingerprint=CE:CD:DC:90:50:99:D8:DA:DF:C5:B1:D2:09:B7:37:CB:E2:C1:8C:FB:2C:10:C0:FF:0B:CF:0D:32:86:FC:1A:A2
+-----BEGIN CERTIFICATE-----
+MIIEMDCCAxigAwIBAgIQUJRs7Bjq1ZxN1ZfvdY+grTANBgkqhkiG9w0BAQUFADCB
+gjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3dy54cmFtcHNlY3VyaXR5LmNvbTEk
+MCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2VydmljZXMgSW5jMS0wKwYDVQQDEyRY
+UmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMDQxMTAxMTcx
+NDA0WhcNMzUwMTAxMDUzNzE5WjCBgjELMAkGA1UEBhMCVVMxHjAcBgNVBAsTFXd3
+dy54cmFtcHNlY3VyaXR5LmNvbTEkMCIGA1UEChMbWFJhbXAgU2VjdXJpdHkgU2Vy
+dmljZXMgSW5jMS0wKwYDVQQDEyRYUmFtcCBHbG9iYWwgQ2VydGlmaWNhdGlvbiBB
+dXRob3JpdHkwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYJB69FbS6
+38eMpSe2OAtp87ZOqCwuIR1cRN8hXX4jdP5efrRKt6atH67gBhbim1vZZ3RrXYCP
+KZ2GG9mcDZhtdhAoWORlsH9KmHmf4MMxfoArtYzAQDsRhtDLooY2YKTVMIJt2W7Q
+DxIEM5dfT2Fa8OT5kavnHTu86M/0ay00fOJIYRyO82FEzG+gSqmUsE3a56k0enI4
+qEHMPJQRfevIpoy3hsvKMzvZPTeL+3o+hiznc9cKV6xkmxnr9A8ECIqsAxcZZPRa
+JSKNNCyy9mgdEm3Tih4U2sSPpuIjhdV6Db1q4Ons7Be7QhtnqiXtRYMh/MHJfNVi
+PvryxS3T/dRlAgMBAAGjgZ8wgZwwEwYJKwYBBAGCNxQCBAYeBABDAEEwCwYDVR0P
+BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFMZPoj0GY4QJnM5i5ASs
+jVy16bYbMDYGA1UdHwQvMC0wK6ApoCeGJWh0dHA6Ly9jcmwueHJhbXBzZWN1cml0
+eS5jb20vWEdDQS5jcmwwEAYJKwYBBAGCNxUBBAMCAQEwDQYJKoZIhvcNAQEFBQAD
+ggEBAJEVOQMBG2f7Shz5CmBbodpNl2L5JFMn14JkTpAuw0kbK5rc/Kh4ZzXxHfAR
+vbdI4xD2Dd8/0sm2qlWkSLoC295ZLhVbO50WfUfXN+pfTXYSNrsf16GBBEYgoyxt
+qZ4Bfj8pzgCT3/3JknOJiWSe5yvkHJEs0rnOfc5vMZnT5r7SHpDwCRR5XCOrTdLa
+IR9NmXmd4c8nnxCbHIgNsIpkQTG4DmyQJKSbXHGPurt+HBvbaoAPIbzp26a3QPSy
+i6mx5O+aGtA9aZnuqCij4Tyz8LIRnM98QObd50N9otg6tamN8jSZxNQQ4Qb9CYQQ
+O+7ETPTsJ3xCwnR8gooJybQDJbw=
+-----END CERTIFICATE-----

--- a/util/tls.go
+++ b/util/tls.go
@@ -1,0 +1,128 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// CipherSuiteNamesToIDs converts a list of cipher suite names to a list of cipher suite IDs
+func CipherSuiteNamesToIDs(cipherSuites []string) (tlsCipherSuites []uint16, err error) {
+	if len(cipherSuites) == 0 {
+		// If no cipher suites are specified, use the default list
+		cipherSuites = []string{
+			"TLS_RSA_WITH_AES_256_CBC_SHA",
+			"TLS_RSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+			"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		}
+	}
+
+	cipherSuiteMap := make(map[string]uint16)
+
+	for _, cipherSuite := range tls.CipherSuites() {
+		cipherSuiteMap[cipherSuite.Name] = cipherSuite.ID
+	}
+
+	for _, cipherSuite := range tls.InsecureCipherSuites() {
+		cipherSuiteMap[cipherSuite.Name] = cipherSuite.ID
+	}
+	for _, cipherSuite := range cipherSuites {
+		cs, ok := cipherSuiteMap[cipherSuite]
+		if !ok {
+			return nil, fmt.Errorf("invalid cipher suite: %s, valid names include %s", cipherSuite, strings.Join(func() []string {
+				keys := make([]string, 0, len(cipherSuiteMap))
+				for key := range cipherSuiteMap {
+					keys = append(keys, key)
+				}
+				return keys
+			}(), ","))
+		}
+		tlsCipherSuites = append(tlsCipherSuites, cs)
+	}
+	return tlsCipherSuites, nil
+}
+
+// TLSVersionToID converts a TLS version name to a TLS version ID
+func TLSVersionToID(version string) (uint16, error) {
+	versions := map[string]uint16{
+		"SSL30": tls.VersionSSL30,
+		"TLS10": tls.VersionTLS10,
+		"TLS11": tls.VersionTLS11,
+		"TLS12": tls.VersionTLS12,
+		"TLS13": tls.VersionTLS13,
+	}
+
+	if _, ok := versions[version]; !ok {
+		return 0, fmt.Errorf("invalid minimum TLS version: %s, valid names include %s", version, strings.Join(func() []string {
+			keys := make([]string, 0, len(versions))
+			for key := range versions {
+				keys = append(keys, key)
+			}
+			return keys
+		}(), ","))
+	}
+	return versions[version], nil
+}
+
+// GetRootCAs reads PEM-encoded certificate data from a file or input argument, parses them into x509 certificates,
+// and adds them to a new certificate pool. It returns the certificate pool and an error if any occurred.
+// If the input argument is nil, it reads the PEM-encoded certificates from the file "/etc/ssl/cert.pem".
+//
+//
+// This is a workaround for the following issue:
+//   https://github.com/golang/go/issues/51991
+//
+// In summary on the latest version of Mac OS X and golang 1.18+, the MAC OS has started enforcing the use of
+// SCTs (Signed Certificate Timestamp) in TLS certificates. This is a good thing, but it breaks with
+// aws internal services like elasticache, which do not use SCTs.
+//
+// The workaround is to import all the system root CAs into a new certificate pool. This will then use
+// golangs certifcate verification logic to check the certificate chain, but will not enforce the SCTs.
+//
+// Hopefully aws will find a solution to this issue and this code can be removed.
+
+func GetRootCAs(pemDataIn []byte) (*x509.CertPool, error) {
+
+	var pemData []byte
+	var err error
+	if pemDataIn == nil {
+		pemData, err = ReadLocalSSLFile()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		pemData = pemDataIn
+	}
+	rootCAs := x509.NewCertPool()
+
+	for len(pemData) > 0 {
+		var block *pem.Block
+		block, pemData = pem.Decode(pemData)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			fmt.Println("Error parsing certificate:", err)
+			continue
+		}
+		rootCAs.AddCert(cert)
+	}
+
+	return rootCAs, nil
+}
+
+func ReadLocalSSLFile() ([]byte, error) {
+	pemData, err := ioutil.ReadFile("/etc/ssl/cert.pem")
+	if err != nil {
+		return nil, err
+	}
+	return pemData, nil
+}

--- a/util/tls_test.go
+++ b/util/tls_test.go
@@ -1,0 +1,78 @@
+package util_test
+
+import (
+	"crypto/tls"
+
+	_ "embed"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/alphagov/paas-cf-conduit/util"
+)
+
+//go:embed testdata/certs.pem
+var pemData []byte
+
+var _ = Describe("util", func() {
+	Describe("CipherSuiteNamesToIDs", func() {
+		It("should return a list of uint16 IDs for the given cipher suite names", func() {
+			cipherSuites := []string{
+				"TLS_RSA_WITH_AES_256_CBC_SHA",
+				"TLS_RSA_WITH_AES_256_GCM_SHA384",
+			}
+			ids, err := CipherSuiteNamesToIDs(cipherSuites)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(ContainElement(tls.TLS_RSA_WITH_AES_256_CBC_SHA))
+			Expect(ids).To(ContainElement(tls.TLS_RSA_WITH_AES_256_GCM_SHA384))
+		})
+
+		It("should return an error if an invalid cipher suite name is provided", func() {
+			cipherSuites := []string{
+				"TLS_RSA_WITH_AES_256_CBC_SHA",
+				"TLS_RSA_WITH_INVALID_CIPHER",
+			}
+			_, err := CipherSuiteNamesToIDs(cipherSuites)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return the default cipher suites if none are provided", func() {
+			ids, err := CipherSuiteNamesToIDs(nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ids).To(ContainElement(tls.TLS_RSA_WITH_AES_256_CBC_SHA))
+			Expect(ids).To(ContainElement(tls.TLS_RSA_WITH_AES_256_GCM_SHA384))
+			Expect(ids).To(ContainElement(tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384))
+			Expect(ids).To(ContainElement(tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384))
+		})
+	})
+
+	Describe("TLSVersionToID", func() {
+		It("should return the int ID for a valid TLS version", func() {
+			version := "TLS12"
+			id, err := TLSVersionToID(version)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal(uint16(tls.VersionTLS12)))
+		})
+
+		It("should return an error if an invalid TLS version is provided", func() {
+			version := "INVALID_VERSION"
+			_, err := TLSVersionToID(version)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("GetRootCAs", func() {
+
+		It("should return CertPool with two subjects", func() {
+			certPool, err := GetRootCAs(pemData)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(certPool.Subjects()).To(HaveLen(2))
+		})
+
+		It("should return 0 certs if passed invalid data", func() {
+			certPool, err := GetRootCAs([]byte("invalid data"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(certPool.Subjects()).To(HaveLen(0))
+		})
+	})
+})


### PR DESCRIPTION
What
----

Toughen up configuration for TLS/SSL when interacting with PaaS via the conduit plugin by adding minimum-tls-version and cipher-suites command line options with sensible defaults.

Why
----

A previous pen test report has indicated that we could have done a better job configuring the CF Client Config in Golang SDK.

How to Review
----
Test and look at the code.

Example tests:

```
cf conduit --minimum-tls-version TLS13  billing-db -- psql
OK Connecting client
Error: Could not get api /v2/info: Get "https://api.dev04.dev.cloudpipeline.digital/v2/info": tls: server selected unsupported protocol version 303
Could not get api /v2/info: Get "https://api.dev04.dev.cloudpipeline.digital/v2/info": tls: server selected unsupported protocol version 303
```

```
cf conduit --cipher-suites TLS_RSA_WITH_RC4_128_SHA  billing-db -- psql
OK Connecting client
Error: Could not get api /v2/info: Get "https://api.dev04.dev.cloudpipeline.digital/v2/info": remote error: tls: handshake failure
Could not get api /v2/info: Get "https://api.dev04.dev.cloudpipeline.digital/v2/info": remote error: tls: handshake failure
```

