### PR TITLE
Specify egress network requirements in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ cf conduit service-1 service-2
 
 Output from the command will report connection details for the tunnel(s) in the foreground, hit Ctrl+C to terminate the connections.
 
+### Networking requirements - Egress
+
+Resources running Conduit will need to be able to route TCP traffic outbound freely on the following ports:
+* 443
+* 2222
+
 ### Conduit apps
 
 Traditionally `cf-conduit` creates an app to implement the tunnel. This app can be named with the `--app-name` option. The app `cf-conduit` created, will be deleted when the tunnel is closed. `--no-delete` option stops `cf-conduit` from deleting the app when the tunnel closes.


### PR DESCRIPTION
In the process of writing some AWS ECS tasks to automate migration, I discovered that the port requirements for Conduit were not entirely predictable.

I don't imagine I will be the only person hitting this problem in 2023 and so I'm offering here some clarification to the docs in the hopes that this will help others migrating from GPaaS.