### PR TITLE
185509385 - Pin GitHub Actions to specific hashes

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
       - name: "Install Go ${{env.GO_VERSION}}"
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
           go-version: "${{env.GO_VERSION}}"
 


### PR DESCRIPTION
Description:
- Currently we pin to versions which means that we automatically pull in the latest changes which presents a security risk as we don't know which code is running in our build pipeline.
- This PR fixes this by pinning to a specific hash
- A future PR will configure dependabot to raise PR's automatically for later versions of GitHub Actions against their hashes